### PR TITLE
some minor changes

### DIFF
--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -13,7 +13,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
   # select performs a query against a table.  The table_name and fields are
   # configured using the sql_mapping directive in your model.  The clause and
   # params is the query and params that is passed in via .all() method
-  def select(table_name, fields, clause = "", params = nil, &block)
+  def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
       stmt << fields.map { |name| "#{table_name}.#{name}" }.join(",")

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -13,7 +13,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   # select performs a query against a table.  The table_name and fields are
   # configured using the sql_mapping directive in your model.  The clause and
   # params is the query and params that is passed in via .all() method
-  def select(table_name, fields, clause = "", params = nil, &block)
+  def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
     clause = _ensure_clause_template(clause)
 
     statement = String.build do |stmt|

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -13,7 +13,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   # select performs a query against a table.  The table_name and fields are
   # configured using the sql_mapping directive in your model.  The clause and
   # params is the query and params that is passed in via .all() method
-  def select(table_name, fields, clause = "", params = nil, &block)
+  def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
       stmt << fields.map { |name| "#{table_name}.#{name}" }.join(",")

--- a/src/granite_orm/associations.cr
+++ b/src/granite_orm/associations.cr
@@ -24,10 +24,9 @@ module Granite::ORM::Associations
       {% children_class = children_table.id[0...-1].camelcase %}
       {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
       {% table_name = SETTINGS[:table_name] || name_space + "s" %}
-      foreign_key = "{{children_table.id}}.{{table_name[0...-1]}}_id"
-      query = "JOIN {{table_name}} on {{table_name}}.id = #{foreign_key} WHERE {{table_name}}.id = ?"
-
       return [] of {{children_class}} unless id
+      foreign_key = "{{children_table.id}}.{{table_name[0...-1]}}_id"
+      query = "WHERE #{foreign_key} = ?"
       {{children_class}}.all(query, id)
     end
   end

--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -16,22 +16,17 @@ class Granite::ORM::Base
   include Settings
   include Table
   include Transactions
+  include Validators
 
   extend Querying
 
   macro inherited
-    include Granite::ORM::Validators
-
     macro finished
-      __process
+      __process_table
+      __process_fields
+      __process_querying
+      __process_transactions
     end
-  end
-
-  macro __process
-    __process_table
-    __process_fields
-    __process_querying
-    __process_transactions
   end
 
   def initialize(**args : Object)

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -56,29 +56,38 @@ module Granite::ORM::Fields
 
     # Cast params and set fields.
     private def cast_to_field(name, value : DB::Any)
-      case name.to_s
-        {% for _name, type in FIELDS %}
-        when "{{_name.id}}"
-          {% if type.id == Int32.id %}
-            @{{_name.id}} = value.to_i32
-          {% elsif type.id == Int64.id %}
-            @{{_name.id}} = value.to_i64
-          {% elsif type.id == Float32.id %}
-            @{{_name.id}} = value.to_f32{0.0}
-          {% elsif type.id == Float64.id %}
-            @{{_name.id}} = value.to_f64{0.0}
-          {% elsif type.id == Bool.id %}
-            @{{_name.id}} = ["1", "yes", "true", true].includes?(value)
-          {% elsif type.id == Time.id %}
-            if value.is_a?(Time)
-              @{{_name.id}} = value
-            elsif value.to_s =~ /\d{4,}-\d{2,}-\d{2,}\s\d{2,}:\d{2,}:\d{2,}/
-              @{{_name.id}} = Time.parse(value, "%F %X")
-            end
-          {% else %}
-            @{{_name.id}} = value.to_s
+      if !value.nil?
+        case name.to_s
+          {% for _name, type in FIELDS %}
+          when "{{_name.id}}"
+            {% if type.id == Int32.id %}
+              @{{_name.id}} = value.to_i32
+            {% elsif type.id == Int64.id %}
+              @{{_name.id}} = value.to_i64
+            {% elsif type.id == Float32.id %}
+              @{{_name.id}} = value.to_f32{0.0}
+            {% elsif type.id == Float64.id %}
+              @{{_name.id}} = value.to_f64{0.0}
+            {% elsif type.id == Bool.id %}
+              @{{_name.id}} = ["1", "yes", "true", true].includes?(value)
+            {% elsif type.id == Time.id %}
+              if value.is_a?(Time)
+                @{{_name.id}} = value
+              elsif value.to_s =~ /\d{4,}-\d{2,}-\d{2,}\s\d{2,}:\d{2,}:\d{2,}/
+                @{{_name.id}} = Time.parse(value.to_s, "%F %X")
+              end
+            {% else %}
+              @{{_name.id}} = value.to_s
+            {% end %}
           {% end %}
-        {% end %}
+        end
+      else
+        case name.to_s
+          {% for _name, type in FIELDS %}
+          when "{{_name.id}}"
+            @{{_name.id}} = nil
+          {% end %}
+        end
       end
     end
   end

--- a/src/granite_orm/validators.cr
+++ b/src/granite_orm/validators.cr
@@ -4,7 +4,9 @@ module Granite::ORM::Validators
   property errors = [] of Error
 
   macro included
-    @@validators = Array({field: Symbol, message: String, block: Proc(self, Bool)}).new
+    macro inherited
+      @@validators = Array({field: Symbol, message: String, block: Proc(self, Bool)}).new
+    end
   end
 
   macro validate(message, block)


### PR DESCRIPTION
#### Change Default Value of `params` in `Granite::Adapter::{{Any}}#select` to `[] of DB::Any`

`db.query` fails when `params` is nil because `db.query` treats it as `[nil]`.

#### Expand `__process` into `finished`

`__process` is not as long as before.

#### Remove `JOIN` in `Granite::ORM::Associations.has_many`

`JOIN` is not necessary because `{{foreign_key}}` is the same as `{{table_name}}.id`.

#### Take `include Validators` out of `macro inherited`

Just like other modules.

#### Make `cast_to_field` Accept nil

Then `.new`, `.create` and `#set_attribute` can be more flexible and convenient.