### PR TITLE
Add to_h and to_json to Granite::ORM::Fields

### DIFF
--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -16,14 +16,14 @@ describe Granite::ORM::Base do
 
   it "should provide a to_h method" do
     t = Todo.new(name: "test todo", priority: 20)
-    result = { "name" => "test todo", "priority": 20 }
+    result = { "name" => "test todo", "priority" => 20, "created_at" => "", "updated_at" => "" }
 
     t.to_h.should eq result
   end
 
   it "should provide a to_json method" do
     t = Todo.new(name: "test todo", priority: 20)
-    result = "{\"name\":\"test todo\",\"priority\":20}"
+    result = %({"name":"test todo","priority":20,"created_at":"","updated_at":""})
 
     t.to_json.should eq result
   end

--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -4,6 +4,7 @@ require "../src/adapter/pg"
 class Todo < Granite::ORM::Base
   adapter pg
   field name : String
+  field priority : Int32
   timestamps
 end
 
@@ -11,5 +12,19 @@ describe Granite::ORM::Base do
   it "should create a new todo object with name set" do
     t = Todo.new(name: "Elorest")
     t.name.should eq "Elorest"
+  end
+
+  it "should provide a to_h method" do
+    t = Todo.new(name: "test todo", priority: 20)
+    result = { "name" => "test todo", "priority": 20 }
+
+    t.to_h.should eq result
+  end
+
+  it "should provide a to_json method" do
+    t = Todo.new(name: "test todo", priority: 20)
+    result = "{\"name\":\"test todo\",\"priority\":20}"
+
+    t.to_json.should eq result
   end
 end

--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -16,14 +16,14 @@ describe Granite::ORM::Base do
 
   it "should provide a to_h method" do
     t = Todo.new(name: "test todo", priority: 20)
-    result = { "name" => "test todo", "priority" => 20, "created_at" => "", "updated_at" => "" }
+    result = { "name" => "test todo", "priority" => 20, "created_at" => nil, "updated_at" => nil }
 
     t.to_h.should eq result
   end
 
   it "should provide a to_json method" do
     t = Todo.new(name: "test todo", priority: 20)
-    result = %({"name":"test todo","priority":20,"created_at":"","updated_at":""})
+    result = %({"name":"test todo","priority":20,"created_at":null,"updated_at":null})
 
     t.to_json.should eq result
   end

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -67,13 +67,8 @@ module Granite::ORM::Fields
         {% end %}
       {% end %}
       {% if SETTINGS[:timestamps] %}
-        if created_at
-          fields["created_at"] = created_at.not_nil!.to_s("%F %X")
-        end
-
-        if updated_at
-          fields["updated_at"] = updated_at.not_nil!.to_s("%F %X")
-        end
+        fields["created_at"] = created_at ? created_at.not_nil!.to_s("%F %X") : ""
+        fields["updated_at"] = updated_at ? updated_at.not_nil!.to_s("%F %X") : ""
       {% end %}
 
       return fields

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -67,8 +67,8 @@ module Granite::ORM::Fields
         {% end %}
       {% end %}
       {% if SETTINGS[:timestamps] %}
-        fields["created_at"] = created_at ? created_at.not_nil!.to_s("%F %X") : ""
-        fields["updated_at"] = updated_at ? updated_at.not_nil!.to_s("%F %X") : ""
+        fields["created_at"] = created_at.try(&.to_s("%F %X"))
+        fields["updated_at"] = updated_at.try(&.to_s("%F %X"))
       {% end %}
 
       return fields


### PR DESCRIPTION
This PR should satisfy the agreed upon resolution of #50 

It adds a `to_h` and `to_json` method to Granite ORM Models.