### PR TITLE
Readme Testing Instructions Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,5 +464,5 @@ CREATE DATABASE granite_db;
 GRANT ALL PRIVILEGES ON granite_db.* TO 'granite'@'localhost' WITH GRANT OPTION;
 ```
 
-3. Export `.env` with `$ export .env`
+3. Export `.env` with `$ source .env`
 4. `$ crystal spec`


### PR DESCRIPTION
I found what appears to be a typo in the instructions while setting up my testing environment.

The instructions say to `$ export .env` where you'd actually use the `source` command to process the file with bash.