### PR TITLE
Use JSON::Builder instead of to_h.to_json

### DIFF
--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -16,15 +16,30 @@ describe Granite::ORM::Base do
 
   it "should provide a to_h method" do
     t = Todo.new(name: "test todo", priority: 20)
-    result = { "name" => "test todo", "priority" => 20, "created_at" => nil, "updated_at" => nil }
+    result = {"name" => "test todo", "priority" => 20, "created_at" => nil, "updated_at" => nil}
 
     t.to_h.should eq result
   end
 
-  it "should provide a to_json method" do
-    t = Todo.new(name: "test todo", priority: 20)
-    result = %({"name":"test todo","priority":20,"created_at":null,"updated_at":null})
+  describe "#to_json" do
+    it "converts object to json" do
+      t = Todo.new(name: "test todo", priority: 20)
+      result = %({"name":"test todo","priority":20,"created_at":null,"updated_at":null})
 
-    t.to_json.should eq result
+      t.to_json.should eq result
+    end
+
+    it "works with collections" do
+      todos = [
+        Todo.new(name: "todo 1", priority: 1),
+        Todo.new(name: "todo 2", priority: 2),
+        Todo.new(name: "todo 3", priority: 3),
+      ]
+
+      collection = JSON.parse todos.to_json
+      collection[0].should eq({"name" => "todo 1", "priority" => 1, "created_at" => nil, "updated_at" => nil})
+      collection[1].should eq({"name" => "todo 2", "priority" => 2, "created_at" => nil, "updated_at" => nil})
+      collection[2].should eq({"name" => "todo 3", "priority" => 3, "created_at" => nil, "updated_at" => nil})
+    end
   end
 end


### PR DESCRIPTION
This change ships two improvements:

1. Build json with [JSON::Builder](https://crystal-lang.org/api/0.23.1/JSON.html#build%28io%3AIO%2Cindent%3Dnil%2C%26block%29-class-method) is faster than `to_h.to_json` (because of transitional hash of course):

```crystal
# ../granite-orm/example.cr

require "benchmark"
require "./src/granite_orm"
require "./src/adapter/sqlite"

class Comment < Granite::ORM::Base
  adapter sqlite
  table_name post_comments
  field name : String
  field body : String
end

s = "string"
c = Comment.new(name: s, body: s)

Benchmark.ips do |x|
  x.report("to_h.to_json") do
    c.to_h.to_json
  end

  x.report("JSON::Builder") do
    c.to_json
  end
end
```

```sh
$ DB_NAME=test.db crystal run example.cr --release                                                                                                               
to_h.to_json 814.53k (  1.23µs) (± 0.98%)  1.49× slower
JSON::Builder   1.22M (822.64ns) (± 1.29%)       fastest
```

2. Allow `to_json` on a collection of model objects, i.e. `user.posts.to_json` should work now. Before there was a compilation error.