### PR TITLE
Add primary key to json and hash

### DIFF
--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -8,23 +8,37 @@ class Todo < Granite::ORM::Base
   timestamps
 end
 
+class WebSite < Granite::ORM::Base
+  adapter pg
+  primary custom_id : Int32
+  field name : String
+end
+
 describe Granite::ORM::Base do
   it "should create a new todo object with name set" do
     t = Todo.new(name: "Elorest")
     t.name.should eq "Elorest"
   end
 
-  it "should provide a to_h method" do
-    t = Todo.new(name: "test todo", priority: 20)
-    result = {"name" => "test todo", "priority" => 20, "created_at" => nil, "updated_at" => nil}
+  describe "#to_h" do
+    it "convert object to hash" do
+      t = Todo.new(name: "test todo", priority: 20)
+      result = {"id" => nil, "name" => "test todo", "priority" => 20, "created_at" => nil, "updated_at" => nil}
 
-    t.to_h.should eq result
+      t.to_h.should eq result
+    end
+
+    it "honors custom primary key" do
+      s = WebSite.new(name: "Hacker News")
+      s.custom_id = 3
+      s.to_h.should eq({"name" => "Hacker News", "custom_id" => 3})
+    end
   end
 
   describe "#to_json" do
     it "converts object to json" do
       t = Todo.new(name: "test todo", priority: 20)
-      result = %({"name":"test todo","priority":20,"created_at":null,"updated_at":null})
+      result = %({"id":null,"name":"test todo","priority":20,"created_at":null,"updated_at":null})
 
       t.to_json.should eq result
     end
@@ -37,9 +51,15 @@ describe Granite::ORM::Base do
       ]
 
       collection = JSON.parse todos.to_json
-      collection[0].should eq({"name" => "todo 1", "priority" => 1, "created_at" => nil, "updated_at" => nil})
-      collection[1].should eq({"name" => "todo 2", "priority" => 2, "created_at" => nil, "updated_at" => nil})
-      collection[2].should eq({"name" => "todo 3", "priority" => 3, "created_at" => nil, "updated_at" => nil})
+      collection[0].should eq({"id" => nil, "name" => "todo 1", "priority" => 1, "created_at" => nil, "updated_at" => nil})
+      collection[1].should eq({"id" => nil, "name" => "todo 2", "priority" => 2, "created_at" => nil, "updated_at" => nil})
+      collection[2].should eq({"id" => nil, "name" => "todo 3", "priority" => 3, "created_at" => nil, "updated_at" => nil})
+    end
+
+    it "honors custom primary key" do
+      s = WebSite.new(name: "Hacker News")
+      s.custom_id = 3
+      s.to_json.should eq %({"custom_id":3,"name":"Hacker News"})
     end
   end
 end

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -59,6 +59,8 @@ module Granite::ORM::Fields
     def to_h
       fields = {} of String => Bool | Float32 | Float64 | Int32 | Int64 | String | Time | Nil
 
+      fields["{{PRIMARY[:name]}}"] = {{PRIMARY[:name]}}
+
       {% for name, type in FIELDS %}
         {% if type.id == Time.id %}
           fields["{{name}}"] = {{name.id}}.try(&.to_s("%F %X"))
@@ -78,6 +80,8 @@ module Granite::ORM::Fields
 
     def to_json(json : JSON::Builder)
       json.object do
+        json.field "{{PRIMARY[:name]}}", {{PRIMARY[:name]}}
+
         {% for name, type in FIELDS %}
           %field, %value = "{{name.id}}", {{name.id}}
           {% if type.id == Time.id %}


### PR DESCRIPTION
This change adds primary key to the result of `to_json` and `to_h`:

```crystal
class User < Granite::ORM::Base
  adapter mysql

  field email : String
  field name : String
  timestamps
end

u = User.new(email: "user1@mail.com", name: "Hero").tap &.save
u.to_json #=> {"id":13,"email":"user1@mail.com","name":"Hero","created_at":"2017-10-18 19:02:18","updated_at":"2017-10-18 19:02:18"}
```

I think `id` (or other custom primary key) is an important attribute especially while creating an API. At any moment developer is able to select/reject attributes:

```crystal
u.to_h.select %w(email name)               #=> {"email" => "user1@mail.com", "name" => "Hero"}
u.to_h.reject %w(id created_at updated_at) #=> {"email" => "user1@mail.com", "name" => "Hero"}
```