### PR TITLE
Adds  Support For Amber

### DIFF
--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -33,7 +33,7 @@ class Granite::ORM::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, DB::Any))
+  def initialize(args : Hash(Symbol | String, Type))
     set_attributes(args)
   end
 

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -1,6 +1,8 @@
 require "json"
 
 module Granite::ORM::Fields
+  alias Type = DB::Any | Hash(String, JSON::Type) | Array(JSON::Type)
+
   macro included
     macro inherited
       FIELDS = {} of Nil => Nil
@@ -57,7 +59,7 @@ module Granite::ORM::Fields
     end
 
     def to_h
-      fields = {} of String => Bool | Float32 | Float64 | Int32 | Int64 | String | Time | Nil
+      fields = {} of String => Type
 
       {% for name, type in FIELDS %}
         {% if type.id == Time.id %}
@@ -134,7 +136,7 @@ module Granite::ORM::Fields
     end
   end
 
-  def set_attributes(args : Hash(Symbol | String, DB::Any))
+  def set_attributes(args : Hash(Symbol | String, DB::Any | Type))
     args.each do |k, v|
       cast_to_field(k, v)
     end


### PR DESCRIPTION
As a developer I want to be able to initialize a Granite Model from
Amber params

See PR https://github.com/amberframework/amber/pull/315

- Adds a Type alias
- Type includes  Hash(String, JSON::Type) | Array(JSON::Type)
- Adds Fields::Type to Base.cr initializer

With this change developers will be able to populate Model objects from
Amber params.validation results.