### PR TITLE
Adds Cast From JSON::Type Support

### DIFF
--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -8,6 +8,16 @@ class Todo < Granite::ORM::Base
   timestamps
 end
 
+class Post < Granite::ORM::Base
+  adapter pg
+  field name : String
+  field priority : Int32
+  field published : Bool
+  field upvotes : Int64
+  field sentiment : Float32
+  timestamps
+end
+
 class WebSite < Granite::ORM::Base
   adapter pg
   primary custom_id : Int32
@@ -18,6 +28,30 @@ describe Granite::ORM::Base do
   it "should create a new todo object with name set" do
     t = Todo.new(name: "Elorest")
     t.name.should eq "Elorest"
+  end
+
+  it "takes JSON::Type" do
+    tmp_hash = {} of String | Symbol => String | JSON::Type
+    body = %({
+      name: "Elias",
+      priotity: 333,
+      published: false,
+      upvotes: 9223372036854775807,
+      sentiment: 3.143333333333
+    })
+
+    case json = JSON.parse_raw(body)
+    when Hash
+      json.each do |key, value|
+        tmp_hash[key.as(String)] = value
+      end
+    when Array
+      tmp_hash["_json"] = json
+    end
+
+    todo = Post.new(tmp_hash)
+    todo.name.should eq "Elias"
+    todo.priority.should eq 333
   end
 
   describe "#to_h" do

--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -33,7 +33,7 @@ class Granite::ORM::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, Type))
+  def initialize(args : Hash(Symbol | String, String | JSON::Type))
     set_attributes(args)
   end
 

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -1,7 +1,7 @@
 require "json"
 
 module Granite::ORM::Fields
-  alias Type = DB::Any | JSON::Type
+  alias Type = DB::Any | JSON::Any
 
   macro included
     macro inherited
@@ -102,8 +102,8 @@ module Granite::ORM::Fields
       end
     end
 
-    # Cast params and set fields.
-    private def cast_to_field(name, value : Type)
+    # Cast params and set fields for String
+    private def cast_to_field(name, value : DB::Any)
       if !value.nil?
         case name.to_s
           {% for _name, type in FIELDS %}
@@ -138,9 +138,19 @@ module Granite::ORM::Fields
         end
       end
     end
+
+    # Sets params
+    private def cast_json_to_field(name, value : JSON::Type)
+    end
   end
 
-  def set_attributes(args : Hash(Symbol | String, Type))
+  def set_attributes(args : Hash(String | Symbol, JSON::Type))
+    args.each do |k, v|
+      cast_json_to_field(k, v.as(JSON::Type))
+    end
+  end
+
+  def set_attributes(args : Hash(Symbol | String, DB::Any))
     args.each do |k, v|
       cast_to_field(k, v)
     end


### PR DESCRIPTION
While testing the Amber master branch we found that there is an error
when passing a JSON::Type to a model.

This corrects that by adding a cast_json_to_field method that take in a
JSON::Type and asserts it to the correct type.

Backwards maintanability when using a Hash of string values or DB::Any.

Downside there are some dupplication in the method body, a necessary evil in this case since there is 2 different method definition. 