### PR TITLE
Adds Cast From JSON::Type Support

### DIFF
--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -33,7 +33,7 @@ class Granite::ORM::Base
     set_attributes(args.to_h)
   end
 
-  def initialize(args : Hash(Symbol | String, Type))
+  def initialize(args : Hash(Symbol | String, String | JSON::Type))
     set_attributes(args)
   end
 


### PR DESCRIPTION
While testing the Amber master branch we found that there is an error
when passing a JSON::Type to a model.

This corrects that by adding a cast_json_to_field method that take in a
JSON::Type and asserts it to the correct type.

Backwards maintanability when using a Hash of string values or DB::Any.