### PR TITLE
Provide find_in_batches and find_each

### DIFF
--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -193,37 +193,6 @@ describe Granite::Adapter::Mysql do
     end
   end
 
-  describe "#find_in_batches" do
-    it "finds records in batches and yields all the records" do
-      role_ids = (0...100).map do |i|
-        Site.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int32 | Nil
-      Site.find_in_batches(batch_size: 10) do |batch|
-        batch.each { |record| found_roles << record.custom_id }
-        batch.size.should eq 10
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
-
-  describe "#find_each" do
-    it "finds all the records" do
-      role_ids = (0...100).map do |i|
-        Site.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int32 | Nil
-      Site.find_each do |record|
-        found_roles << record.custom_id
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
-
   describe "#belongs_to" do
     it "provides a method to retrieve parent" do
       owner = Owner.new

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -82,6 +82,7 @@ describe Granite::Adapter::Pg do
   Spec.before_each do
     Parent.clear
     User.clear
+    Role.clear
   end
 
   describe "#all" do
@@ -225,6 +226,37 @@ describe Granite::Adapter::Pg do
     end
   end
 
+  describe "#find_in_batches" do
+    it "finds records in batches and yields all the records" do
+      role_ids = (0...100).map do |i|
+        Role.new(name: "role_#{i}").tap {|r| r.save }
+      end.map(&.custom_id)
+
+      found_roles = [] of Int32 | Nil
+      Role.find_in_batches(batch_size: 10) do |batch|
+        batch.each { |record| found_roles << record.custom_id }
+        batch.size.should eq 10
+      end
+
+      found_roles.compact.sort.should eq role_ids.compact
+    end
+  end
+
+  describe "#find_each" do
+    it "finds all the records" do
+      role_ids = (0...100).map do |i|
+        Role.new(name: "role_#{i}").tap {|r| r.save }
+      end.map(&.custom_id)
+
+      found_roles = [] of Int32 | Nil
+      Role.find_each do |record|
+        found_roles << record.custom_id
+      end
+
+      found_roles.compact.sort.should eq role_ids.compact
+    end
+  end
+
   describe "#belongs_to" do
     it "provides a method to retrieve parent" do
       parent = Parent.new
@@ -345,10 +377,6 @@ describe Granite::Adapter::Pg do
   end
 
   describe "Role model with custom primary key" do
-    Spec.before_each do
-      Role.clear
-    end
-
     describe "#find" do
       it "finds the role by custom_id" do
         role = Role.new

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -226,37 +226,6 @@ describe Granite::Adapter::Pg do
     end
   end
 
-  describe "#find_in_batches" do
-    it "finds records in batches and yields all the records" do
-      role_ids = (0...100).map do |i|
-        Role.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int32 | Nil
-      Role.find_in_batches(batch_size: 10) do |batch|
-        batch.each { |record| found_roles << record.custom_id }
-        batch.size.should eq 10
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
-
-  describe "#find_each" do
-    it "finds all the records" do
-      role_ids = (0...100).map do |i|
-        Role.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int32 | Nil
-      Role.find_each do |record|
-        found_roles << record.custom_id
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
-
   describe "#belongs_to" do
     it "provides a method to retrieve parent" do
       parent = Parent.new

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -142,6 +142,41 @@ describe Granite::Adapter::Sqlite do
     end
   end
 
+  describe "#find_in_batches" do
+    it "finds records in batches and yields all the records" do
+      Reaction.clear
+
+      role_ids = (0...100).map do |i|
+        Reaction.new(name: "role_#{i}").tap {|r| r.save }
+      end.map(&.custom_id)
+
+      found_roles = [] of Int64 | Nil
+      Reaction.find_in_batches(batch_size: 10) do |batch|
+        batch.each { |record| found_roles << record.custom_id }
+        batch.size.should eq 10
+      end
+
+      found_roles.compact.sort.should eq role_ids.compact
+    end
+  end
+
+  describe "#find_each" do
+    it "finds all the records" do
+      Reaction.clear
+
+      role_ids = (0...100).map do |i|
+        Reaction.new(name: "role_#{i}").tap {|r| r.save }
+      end.map(&.custom_id)
+
+      found_roles = [] of Int64 | Nil
+      Reaction.find_each do |record|
+        found_roles << record.custom_id
+      end
+
+      found_roles.compact.sort.should eq role_ids.compact
+    end
+  end
+
   describe "#belongs_to" do
     it "provides a method to retrieve parent" do
       comment_thread = CommentThread.new

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -142,40 +142,6 @@ describe Granite::Adapter::Sqlite do
     end
   end
 
-  describe "#find_in_batches" do
-    it "finds records in batches and yields all the records" do
-      Reaction.clear
-
-      role_ids = (0...100).map do |i|
-        Reaction.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int64 | Nil
-      Reaction.find_in_batches(batch_size: 10) do |batch|
-        batch.each { |record| found_roles << record.custom_id }
-        batch.size.should eq 10
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
-
-  describe "#find_each" do
-    it "finds all the records" do
-      Reaction.clear
-
-      role_ids = (0...100).map do |i|
-        Reaction.new(name: "role_#{i}").tap {|r| r.save }
-      end.map(&.custom_id)
-
-      found_roles = [] of Int64 | Nil
-      Reaction.find_each do |record|
-        found_roles << record.custom_id
-      end
-
-      found_roles.compact.sort.should eq role_ids.compact
-    end
-  end
 
   describe "#belongs_to" do
     it "provides a method to retrieve parent" do

--- a/spec/granite_orm/querying_spec.cr
+++ b/spec/granite_orm/querying_spec.cr
@@ -1,0 +1,172 @@
+require "../spec_helper"
+
+{% for adapter in ["pg","mysql","sqlite"] %}
+
+  {%
+   suffix = adapter.camelcase.id
+   adapter_literal = adapter.id
+
+   model_constant = "Parent#{suffix}".id
+   model_string = "Parent#{suffix}".underscore.id
+   model_table = model_string + "s"
+
+   if adapter == "pg"
+     primary_key_sql = "id SERIAL PRIMARY KEY".id
+   elsif adapter == "mysql"
+     primary_key_sql = "id INT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
+   elsif adapter == "sqlite"
+     primary_key_sql = "id INTEGER NOT NULL PRIMARY KEY".id
+   end
+  %}
+
+  require "../src/adapter/{{ adapter_literal }}"
+
+  class {{ model_constant }} < Granite::ORM::Base
+    primary id : Int32
+    adapter {{ adapter_literal }}
+    table_name {{ model_table }}
+
+    field name : String
+  end
+
+  {{ model_constant }}.exec("DROP TABLE IF EXISTS {{ model_table }};")
+  {{ model_constant }}.exec("CREATE TABLE {{ model_table }} (
+    {{ primary_key_sql }},
+    name VARCHAR(10)
+  );
+  ")
+
+  describe {{ adapter }} do
+    Spec.before_each do
+      {{ model_constant }}.clear
+    end
+
+    describe "#find_in_batches" do
+      it "finds records in batches and yields all the records" do
+        model_ids = (0...100).map do |i|
+          {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        end.map(&.id)
+
+        found_models = [] of Int32 | Nil
+        {{ model_constant }}.find_in_batches(batch_size: 10) do |batch|
+          batch.each { |model| found_models << model.id }
+          batch.size.should eq 10
+        end
+
+        found_models.compact.sort.should eq model_ids.compact
+      end
+
+      it "doesnt yield when no records are found" do
+        {{ model_constant }}.find_in_batches do |model|
+          fail "find_in_batches did yield but shouldn't have"
+        end
+      end
+
+      it "errors when batch_size is < 1" do
+        expect_raises ArgumentError do
+          {{ model_constant }}.find_in_batches batch_size: 0 do |model|
+            fail "should have raised"
+          end
+        end
+      end
+
+      it "returns a small batch when there arent enough results" do
+        (0...9).each do |i|
+          {{ model_constant }}.new(name: "model_#{i}").save
+        end
+
+        {{ model_constant }}.find_in_batches(batch_size: 11) do |batch|
+          batch.size.should eq 9
+        end
+      end
+
+      it "can start from an offset other than 0" do
+        created_models = (0...10).map do |i|
+          {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        end.map(&.id)
+
+        # discard the first two models
+        created_models.shift
+        created_models.shift
+
+        found_models = [] of Int32 | Nil
+
+        {{ model_constant }}.find_in_batches(offset: 2) do |batch|
+          batch.each do |model|
+            found_models << model.id
+          end
+        end
+
+        found_models.compact.sort.should eq created_models.compact
+      end
+
+      it "doesnt obliterate a parameterized query" do
+        created_models = (0...10).map do |i|
+          {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        end.map(&.id)
+
+        looking_for_ids = created_models[0...5]
+
+        {{ model_constant }}.find_in_batches("WHERE id IN(#{looking_for_ids.join(",")})") do |batch|
+          batch.map(&.id).compact.should eq looking_for_ids
+        end
+      end
+    end
+
+    describe "#find_each" do
+      it "finds all the records" do
+        model_ids = (0...100).map do |i|
+          {{ model_constant }}.new(name: "role_#{i}").tap {|r| r.save }
+        end.map(&.id)
+
+        found_roles = [] of Int32 | Nil
+        {{ model_constant }}.find_each do |model|
+          found_roles << model.id
+        end
+
+        found_roles.compact.sort.should eq model_ids.compact
+      end
+
+      it "doesnt yield when no records are found" do
+        {{ model_constant }}.find_each do |model|
+          fail "did yield"
+        end
+      end
+
+      it "can start from an offset" do
+        created_models = (0...10).map do |i|
+          {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        end.map(&.id)
+
+        # discard the first two models
+        created_models.shift
+        created_models.shift
+
+        found_models = [] of Int32 | Nil
+
+        {{ model_constant }}.find_each(offset: 2) do |model|
+          found_models << model.id
+        end
+
+        found_models.compact.sort.should eq created_models.compact
+      end
+
+      it "doesnt obliterate a parameterized query" do
+        created_models = (0...10).map do |i|
+          {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        end.map(&.id)
+
+        looking_for_ids = created_models[0...5]
+
+        found_models = [] of Int32 | Nil
+        {{ model_constant }}.find_each("WHERE id IN(#{looking_for_ids.join(",")})") do |model|
+          found_models << model.id
+        end
+
+        found_models.compact.should eq looking_for_ids
+      end
+    end
+
+  end
+
+{% end %}

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -21,6 +21,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << fields.map { |name| "#{table_name}.#{name}" }.join(",")
       stmt << " FROM #{table_name} #{clause}"
     end
+
     open do |db|
       db.query statement, params do |rs|
         yield rs
@@ -36,6 +37,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << " FROM #{table_name}"
       stmt << " WHERE #{field}=$1 LIMIT 1"
     end
+
     open do |db|
       db.query_one? statement, id do |rs|
         yield rs
@@ -51,6 +53,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << fields.map { |name| "$#{fields.index(name).not_nil! + 1}" }.join(",")
       stmt << ")"
     end
+
     open do |db|
       db.exec statement, params
       return db.scalar(last_val()).as(Int64)
@@ -68,6 +71,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << fields.map { |name| "#{name}=$#{fields.index(name).not_nil! + 1}" }.join(",")
       stmt << " WHERE #{primary_name}=$#{fields.size + 1}"
     end
+
     open do |db|
       db.exec statement, params
     end
@@ -75,8 +79,10 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
 
   # This will delete a row from the database.
   def delete(table_name, primary_name, value)
+    statement = "DELETE FROM #{table_name} WHERE #{primary_name}=$1"
+
     open do |db|
-      db.exec "DELETE FROM #{table_name} WHERE #{primary_name}=$1", value
+      db.exec statement, value
     end
   end
 

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -80,6 +80,10 @@ module Granite::ORM::Querying
   end
 
   def find_in_batches(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)
+    if limit < 1
+      raise ArgumentError.new("batch_size must be >= 1")
+    end
+
     while true
       results = all "#{clause} LIMIT ? OFFSET ?", params + [limit, offset]
       break unless results.any?

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -81,7 +81,7 @@ module Granite::ORM::Querying
 
   def find_in_batches(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)
     while true
-      results = all "#{clause} LIMIT #{limit} OFFSET #{offset}"
+      results = all "#{clause} LIMIT ? OFFSET ?", params + [limit, offset]
       break unless results.any?
       yield results
       offset += limit

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -71,6 +71,23 @@ module Granite::ORM::Querying
     return row
   end
 
+  def find_each(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)
+    find_in_batches(clause, params, batch_size: limit, offset: offset) do |batch|
+      batch.each do |record|
+        yield record
+      end
+    end
+  end
+
+  def find_in_batches(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)
+    while true
+      results = all "#{clause} LIMIT #{limit} OFFSET #{offset}"
+      break unless results.any?
+      yield results
+      offset += limit
+    end
+  end
+
   def exec(clause = "")
     @@adapter.open { |db| db.exec(clause) }
   end


### PR DESCRIPTION
I'm unsure if this is in the spirit of this project or not, so I wanted to put some code out there and start a discussion before investing enough time to complete the algorithm and write specs.

`.all` is a fine way to deal with a couple hundred or so rows in a table, but above that it becomes a performance risk. ActiveRecord provides a nice way to get around this problem by fetching N rows from the database at once, and iterating over them in step. `find_each` iterates individual records and `find_in_batches` iterates batches as arrays of records. I consider this pattern essential for large datasets.

I noticed that there aren't any tests around the existing finders, which might mean that I'd struggle to set an acceptable spec pattern for these finders.

Assuming that these functions are a desireable addition to granite, here is a list of things I think might be needed to merge this in:

- [x] `find_in_batches` does not deal at all with the parameterized query components
- [x] ~it also should check for limit and offset already present in the sql string? The only precedent here is `first` which does not check for the presence of `LIMIT` at all, so maybe not.~
- [x] ~returning a lot of rows with SQL `LIMIT` and `OFFSET` isn't the best pattern for these functions, but I think it is minimally viable for all the drivers. Postgres has cursors, I'm not sure what the rest of the databases have. The weakness of `LIMIT`/`OFFSET` is that if the database is modified by the code here or elsewhere, duplicated or missing rows are possible.~ This should be implemented elsewhere / later, I think. It'll require diving into the database drivers explicitly.
- [x] specs for this code?

Thoughts?