### PR TITLE
fixed cast to bool for json type

### DIFF
--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -171,7 +171,7 @@ module Granite::ORM::Fields
             {% elsif type.id == Float64.id %}
               @{{_name.id}} = value.as(Float64)
             {% elsif type.id == Bool.id %}
-              @{{_name.id}} = value.as(Bool)
+              @{{_name.id}} = ["1", "yes", "true", true].includes?(value)
             {% elsif type.id == Time.id %}
               if value.is_a?(Time)
                 @{{_name.id}} = value


### PR DESCRIPTION
Today I tried amber :) It's very cool! 2ms! fantastic!... 
But my simple generated model was not working, until i made this fix. :)

require "granite_orm/adapter/mysql"
class Post < Granite::ORM::Base
  adapter mysql
  table_name posts

  field name : String
  field body : String
  field draft : Bool
  timestamps
end