### PR TITLE
Dj/support setting database url directly

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -8,7 +8,7 @@ abstract class Granite::Adapter::Base
   property database : DB::Database
 
   def initialize(adapter : String)
-    if url = ENV["DATABASE_URL"]? || replace_env_vars(settings(adapter)["database"].to_s)
+    if url = ENV["DATABASE_URL"]? || Granite::ORM.settings.database_url || replace_env_vars(settings(adapter)["database"].to_s)
       @database = DB.open(url)
     else
       raise "database url needs to be set in the config/database.yml or DATABASE_URL environment variable"

--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -13,7 +13,6 @@ class Granite::ORM::Base
   include Associations
   include Callbacks
   include Fields
-  include Settings
   include Table
   include Transactions
   include Validators

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -82,15 +82,4 @@ module Granite::ORM::Querying
   def scalar(clause = "", &block)
     @@adapter.open { |db| yield db.scalar(clause) }
   end
-
-  def create(**args)
-    create(args.to_h)
-  end
-
-  def create(args : Hash(Symbol | String, DB::Any))
-    instance = new
-    instance.set_attributes(args)
-    instance.save
-    instance
-  end
 end

--- a/src/granite_orm/settings.cr
+++ b/src/granite_orm/settings.cr
@@ -1,7 +1,9 @@
-module Granite::ORM::Settings
-  macro included
-    macro inherited
-      SETTINGS = {} of Nil => Nil
-    end
+module Granite::ORM
+  class Settings
+    property database_url : String? = nil
+  end
+
+  def self.settings
+    @@settings ||= Settings.new
   end
 end

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -8,7 +8,7 @@ module Granite::ORM::Table
   # specify the database adapter you will be using for this model.
   # mysql, pg, sqlite, etc.
   macro adapter(name)
-    @@adapter = Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
+    @@adapter ||= Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
 
     def self.adapter
       @@adapter

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -1,6 +1,7 @@
 module Granite::ORM::Table
   macro included
     macro inherited
+      SETTINGS = {} of Nil => Nil
       PRIMARY = {name: id, type: Int64}
     end
   end
@@ -8,7 +9,7 @@ module Granite::ORM::Table
   # specify the database adapter you will be using for this model.
   # mysql, pg, sqlite, etc.
   macro adapter(name)
-    @@adapter ||= Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
+    @@adapter = Granite::Adapter::{{name.id.capitalize}}.new("{{name.id}}")
 
     def self.adapter
       @@adapter

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -54,4 +54,15 @@ module Granite::ORM::Transactions
       end
     end
   end
+
+  def create(**args)
+    create(args.to_h)
+  end
+
+  def create(args : Hash(Symbol | String, DB::Any))
+    instance = new
+    instance.set_attributes(args)
+    instance.save
+    instance
+  end
 end


### PR DESCRIPTION
This allows you to set the database url directly using `Granite::ORM.settings.database_url`. 

If the DATABASE_URL exists, it will use that as highest priority.  If the `settings.database_url` is set directly, it will use that as the second priority.  Finally it will look for a `config/database.yml` and use that if it exists as third priority.