### PR TITLE
forces timestamps to be in UTC

### DIFF
--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -391,4 +391,50 @@ describe Granite::Adapter::Mysql do
       end
     end
   end
+
+  describe "timestamps" do
+    it "uses UTC for created_at" do
+      role = Owner.new(name: "test").tap(&.save)
+      same_role = Owner.find(role.id).not_nil!
+
+      original_timestamp = role.created_at.not_nil!
+      read_timestamp = same_role.created_at.not_nil!
+
+      original_timestamp.kind.should eq Time::Kind::Utc
+      read_timestamp.kind.should eq Time::Kind::Unspecified
+    end
+
+    it "uses UTC for updated_at" do
+      role = Owner.new(name: "test").tap(&.save)
+      same_role = Owner.find(role.id).not_nil!
+
+      original_timestamp = role.updated_at.not_nil!
+      read_timestamp = same_role.updated_at.not_nil!
+
+      original_timestamp.kind.should eq Time::Kind::Utc
+      read_timestamp.kind.should eq Time::Kind::Unspecified
+    end
+
+    it "truncates the subsecond parts of created_at" do
+      role = Owner.new(name: "test").tap(&.save)
+      same_role = Owner.find(role.id).not_nil!
+
+      original_timestamp = role.created_at.not_nil!
+      read_timestamp = same_role.created_at.not_nil!
+      hacked_timestamp = Time.new(read_timestamp.ticks, kind: Time::Kind::Utc)
+
+      original_timestamp.epoch_f.to_i.should eq hacked_timestamp.epoch
+    end
+
+    it "truncates the subsecond parts of updated_at" do
+      role = Owner.new(name: "test").tap(&.save)
+
+      original_timestamp = role.updated_at.not_nil!
+      same_role = Owner.find(role.id).not_nil!
+      read_timestamp = same_role.updated_at.not_nil!
+      hacked_timestamp = Time.new(read_timestamp.ticks, kind: Time::Kind::Utc)
+
+      original_timestamp.epoch_f.to_i.should eq hacked_timestamp.epoch
+    end
+  end
 end

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -386,4 +386,48 @@ describe Granite::Adapter::Pg do
       end
     end
   end
+
+  describe "timestamps" do
+    it "consistently uses UTC for created_at" do
+      role = Parent.new(name: "test").tap(&.save)
+      same_role = Parent.find(role.id).not_nil!
+
+      original_timestamp = role.created_at.not_nil!
+      read_timestamp = same_role.created_at.not_nil!
+
+      original_timestamp.kind.should eq Time::Kind::Utc
+      read_timestamp.kind.should eq Time::Kind::Utc
+    end
+
+    it "consistently uses UTC for updated_at" do
+      role = Parent.new(name: "test").tap(&.save)
+      same_role = Parent.find(role.id).not_nil!
+
+      original_timestamp = role.updated_at.not_nil!
+      read_timestamp = same_role.updated_at.not_nil!
+
+      original_timestamp.kind.should eq Time::Kind::Utc
+      read_timestamp.kind.should eq Time::Kind::Utc
+    end
+
+    it "truncates the subsecond parts of created_at" do
+      role = Parent.new(name: "test").tap(&.save)
+      same_role = Parent.find(role.id).not_nil!
+
+      original_timestamp = role.created_at.not_nil!
+      read_timestamp = same_role.created_at.not_nil!
+
+      original_timestamp.epoch_f.to_i.should eq read_timestamp.epoch
+    end
+
+    it "truncates the subsecond parts of updated_at" do
+      role = Parent.new(name: "test").tap(&.save)
+      same_role = Parent.find(role.id).not_nil!
+
+      original_timestamp = role.updated_at.not_nil!
+      read_timestamp = same_role.updated_at.not_nil!
+
+      original_timestamp.epoch_f.to_i.should eq read_timestamp.epoch
+    end
+  end
 end

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -3,6 +3,9 @@ module Granite::ORM::Transactions
     {% primary_name = PRIMARY[:name] %}
     {% primary_type = PRIMARY[:type] %}
 
+    @updated_at : Time?
+    @created_at : Time?
+
     # The save method will check to see if the primary exists yet. If it does it
     # will call the update method, otherwise it will call the create method.
     # This will update the timestamps apropriately.
@@ -11,15 +14,15 @@ module Granite::ORM::Transactions
         __run_before_save
         if value = @{{primary_name}}
           __run_before_update
-          @updated_at = Time.now
+          @updated_at = Time.now.to_utc
           params_and_pk = params
           params_and_pk << value
           @@adapter.update @@table_name, @@primary_name, self.class.fields, params_and_pk
           __run_after_update
         else
           __run_before_create
-          @created_at = Time.now
-          @updated_at = Time.now
+          @created_at = Time.now.to_utc
+          @updated_at = Time.now.to_utc
           {% if primary_type.id == "Int32" %}
             @{{primary_name}} = @@adapter.insert(@@table_name, self.class.fields, params).to_i32
           {% else %}


### PR DESCRIPTION
fixes #95 

This does not bring the mysql adapter into parity with postgresql because the mysql adapter returns `Time::Kind::Unspecified` instead of `Time::Kind::Utc`, however as the tests illustrate, the ticks behind the timestamp are correct.

Postgresql was the closest to consistent already, so this seems to make postgresql timestamps work as expected.

Sqlite is not addressed because of #29 

