### PR TITLE
Query logger

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -14,6 +14,8 @@ end
 require "../src/granite_orm"
 require "./spec_models"
 
+Granite::ORM.settings.logger = ::Logger.new(nil)
+
 GraniteExample.model_classes.each do |model|
   model.drop_and_create
 end

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -31,6 +31,10 @@ abstract class Granite::Adapter::Base
     yield @database
   end
 
+  def log(query : String, params = [] of String) : Nil
+    Granite::ORM.settings.logger.info "#{query}: #{params}"
+  end
+
   # remove all rows from a table and reset the counter on the id.
   abstract def clear(table_name)
 

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -6,7 +6,9 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   # remove all rows from a table and reset the counter on the id.
   def clear(table_name)
     statement = "DELETE FROM #{table_name}"
+
     log statement
+
     open do |db|
       db.exec statement
     end
@@ -24,7 +26,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << " FROM #{table_name} #{clause}"
     end
 
-    log statement
+    log statement, params
 
     open do |db|
       db.query statement, params do |rs|
@@ -42,7 +44,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
       stmt << " WHERE #{field}=$1 LIMIT 1"
     end
 
-    log statement
+    log statement, id
 
     open do |db|
       db.query_one? statement, id do |rs|
@@ -54,7 +56,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   def insert(table_name, fields, params)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{table_name} ("
-      stmt << fields.map { |name| "#{name}" }.join(",")
+      stmt << fields.map { |name| "#{name}" }.join(", ")
       stmt << ") VALUES ("
       stmt << fields.map { |name| "$#{fields.index(name).not_nil! + 1}" }.join(", ")
       stmt << ")"
@@ -91,7 +93,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
   def delete(table_name, primary_name, value)
     statement = "DELETE FROM #{table_name} WHERE #{primary_name}=$1"
 
-    log statement
+    log statement, value
 
     open do |db|
       db.exec statement, value

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -5,8 +5,12 @@ require "sqlite3"
 class Granite::Adapter::Sqlite < Granite::Adapter::Base
   # remove all rows from a table and reset the counter on the id.
   def clear(table_name)
+    statement = "DELETE FROM #{table_name}"
+
+    log statement
+
     open do |db|
-      db.exec "DELETE FROM #{table_name}"
+      db.exec statement
     end
   end
 
@@ -16,9 +20,12 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   def select(table_name, fields, clause = "", params = [] of DB::Any, &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
-      stmt << fields.map { |name| "#{table_name}.#{name}" }.join(",")
+      stmt << fields.map { |name| "#{table_name}.#{name}" }.join(", ")
       stmt << " FROM #{table_name} #{clause}"
     end
+
+    log statement, params
+
     open do |db|
       db.query statement, params do |rs|
         yield rs
@@ -30,10 +37,13 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   def select_one(table_name, fields, field, id, &block)
     statement = String.build do |stmt|
       stmt << "SELECT "
-      stmt << fields.map { |name| "#{table_name}.#{name}" }.join(",")
+      stmt << fields.map { |name| "#{table_name}.#{name}" }.join(", ")
       stmt << " FROM #{table_name}"
       stmt << " WHERE #{field}=:id LIMIT 1"
     end
+
+    log statement, id
+
     open do |db|
       db.query_one? statement, id do |rs|
         yield rs
@@ -44,11 +54,14 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   def insert(table_name, fields, params)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{table_name} ("
-      stmt << fields.map { |name| "#{name}" }.join(",")
+      stmt << fields.map { |name| "#{name}" }.join(", ")
       stmt << ") VALUES ("
-      stmt << fields.map { |name| "?" }.join(",")
+      stmt << fields.map { |name| "?" }.join(", ")
       stmt << ")"
     end
+
+    log statement, params
+
     open do |db|
       db.exec statement, params
       return db.scalar(last_val()).as(Int64)
@@ -63,9 +76,12 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
   def update(table_name, primary_name, fields, params)
     statement = String.build do |stmt|
       stmt << "UPDATE #{table_name} SET "
-      stmt << fields.map { |name| "#{name}=?" }.join(",")
+      stmt << fields.map { |name| "#{name}=?" }.join(", ")
       stmt << " WHERE #{primary_name}=?"
     end
+
+    log statement, params
+
     open do |db|
       db.exec statement, params
     end
@@ -73,8 +89,12 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
   # This will delete a row from the database.
   def delete(table_name, primary_name, value)
+    statement = "DELETE FROM #{table_name} WHERE #{primary_name}=?"
+
+    log statement, value
+
     open do |db|
-      db.exec "DELETE FROM #{table_name} WHERE #{primary_name}=?", value
+      db.exec statement, value
     end
   end
 end

--- a/src/granite_orm/settings.cr
+++ b/src/granite_orm/settings.cr
@@ -1,6 +1,14 @@
+require "logger"
+
 module Granite::ORM
   class Settings
     property database_url : String? = nil
+    property logger : Logger
+
+    def initialize
+      @logger = Logger.new STDOUT
+      @logger.progname = "Granite"
+    end
   end
 
   def self.settings


### PR DESCRIPTION
This makes room for Granite to log queries to a logger. Hopefully it can then be integrated with Amber Logger. This will be especially helpful for prototyping changes to the ORM. I've had the basics of this code in a stash for several months and it's been very handy when experimenting with the ORM.

One of the more useful features of Rails is the transparent logging of database queries. Hopefully this can provide similar utility.

My initial stab at integrating this with the Amber logger required no changes beyond adding this line to the `initializers/granite.cr`:

```crystal
Granite::ORM.settings.logger = Amber.settings.logger
```

However, that leaves the log output a little less clean that desired. Nevertheless I believe the integration with Amber::Logger will be straightforward.

Comments appreciated.

## To do:

- [x] get initial feedback about this idea (@amberframework/core-team please chime in)
- [x] add logging statements for other adapters
- [ ] ~filter parameters, or tap into log filtering in Amber?~
- [ ] ~Better initial logger format?~
- [x] deadletter logger for testing? (Logs shouldn't show up during `crystal spec`)

## Screenshot

Specifically, the highlighted line in the middle.

![image](https://user-images.githubusercontent.com/208647/34619900-f2c3b7ba-f200-11e7-9751-a2b24863465d.png)

fixes #86 