### PR TITLE
Make CI badge left aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,8 @@ the [Crystal](https://github.com/manastech/crystal) language.
 
 This project is to provide an ORM in Crystal.
 
-  <p align="center">
-    <a href="https://travis-ci.org/amberframework/granite-orm"><img src="https://img.shields.io/travis/amberframework/granite-orm.svg?maxAge=360"></a>
-  </p>
-  
+[![Build Status](https://img.shields.io/travis/amberframework/granite-orm.svg?maxAge=360)](https://travis-ci.org/amberframework/granite-orm)
+
 ## Installation
 
 Add this library to your projects dependencies along with the driver in


### PR DESCRIPTION
Hi, I understand that amber badges are centered, but I think we should keep this one left aligned

I think these look better:

![screenshot_20180114_120839](https://user-images.githubusercontent.com/3067335/34918625-a911ad78-f923-11e7-9845-fbf2a6e6587a.png)

![screenshot_20180114_120912](https://user-images.githubusercontent.com/3067335/34918627-bc8a8c1c-f923-11e7-8757-6f97dd682723.png)


Than this:

![screenshot_20180114_120804](https://user-images.githubusercontent.com/3067335/34918622-940537e2-f923-11e7-8d9b-faa4d5f2f6da.png)
