### PR TITLE
[Logger] Improves query logging readability

### DIFF
--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -1,3 +1,4 @@
+require "colorize"
 require "../granite_orm"
 require "db"
 
@@ -5,6 +6,12 @@ require "db"
 # objects to perform actions against a specific database.  Each adapter needs
 # to implement these methods.
 abstract class Granite::Adapter::Base
+  DATABASE_YML = "config/database.yml"
+  SQL_KEYWORDS_REGEX = %r(SELECT|FROM|WHERE|LIMIT|INNER|VALUES|ORDER|UPDATE|INSERT|DELETE|DROP|
+  LEFT|RIGHT|GROUP|HAVING|GROUP|BY|CREATE|EXISTS)
+
+  Colorize.enabled = Granite::ORM.settings.colorize?
+
   property database : DB::Database
 
   def initialize(adapter : String)
@@ -14,8 +21,6 @@ abstract class Granite::Adapter::Base
       raise "database url needs to be set in the config/database.yml or DATABASE_URL environment variable"
     end
   end
-
-  DATABASE_YML = "config/database.yml"
 
   def settings(adapter : String)
     if File.exists?(DATABASE_YML) &&
@@ -32,7 +37,8 @@ abstract class Granite::Adapter::Base
   end
 
   def log(query : String, params = [] of String) : Nil
-    Granite::ORM.settings.logger.info "#{query}: #{params}"
+    Granite::ORM.settings.logger.info query.gsub(SQL_KEYWORDS_REGEX, "\\0".colorize(:white).mode(:bold).to_s )
+    Granite::ORM.settings.logger.info params
   end
 
   # remove all rows from a table and reset the counter on the id.

--- a/src/granite_orm/settings.cr
+++ b/src/granite_orm/settings.cr
@@ -4,6 +4,7 @@ module Granite::ORM
   class Settings
     property database_url : String? = nil
     property logger : Logger
+    property? colorize : Bool = true
 
     def initialize
       @logger = Logger.new STDOUT


### PR DESCRIPTION

I find it a little hard to spot the Grantite log line in the console

- Adds colorization to SQL keywords to highlight better the SQL queries
being logged to the console
- Adds setting to turn off colorization.

With this changes is easier to read the SQL logged line.


<img width="927" alt="screen shot 2018-01-15 at 9 35 28 am" src="https://user-images.githubusercontent.com/1685772/34948032-f7c9f716-f9d9-11e7-86c5-ab6d445ea9fd.png">