### PR TITLE
add error if casting fails

### DIFF
--- a/spec/granite_orm/fields/casting_spec.cr
+++ b/spec/granite_orm/fields/casting_spec.cr
@@ -1,0 +1,25 @@
+# class Review{{ adapter_const_suffix }} < Granite::ORM::Base
+#   field name : String
+#   field downvotes : Int32
+#   field upvotes : Int64
+#   field sentiment : Float32
+#   field interest : Float64
+#   field published : Bool
+#   field created_at : Time
+# end
+
+{% for adapter in GraniteExample::ADAPTERS %}
+  {% model_constant = "Review#{adapter.camelcase.id}".id %}
+
+  describe "{{ adapter.id }} #casting_to_fields" do
+    it "casts string to int" do
+      model = {{ model_constant }}.new({ "downvotes" => "32" })
+      model.downvotes.should eq 32
+    end
+
+    it "generates an error if casting fails" do
+      model = {{ model_constant }}.new({ "downvotes" => "" })
+      model.errors.size.should eq 1
+    end
+  end
+{% end %}

--- a/spec/granite_orm/fields/casting_spec.cr
+++ b/spec/granite_orm/fields/casting_spec.cr
@@ -1,13 +1,3 @@
-# class Review{{ adapter_const_suffix }} < Granite::ORM::Base
-#   field name : String
-#   field downvotes : Int32
-#   field upvotes : Int64
-#   field sentiment : Float32
-#   field interest : Float64
-#   field published : Bool
-#   field created_at : Time
-# end
-
 {% for adapter in GraniteExample::ADAPTERS %}
   {% model_constant = "Review#{adapter.camelcase.id}".id %}
 

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -9,13 +9,14 @@ end
     adapter_suffix = "_#{adapter.id}".id
     adapter_literal = adapter.id
 
-    parent_table = "parent_#{ adapter_literal }s".id
-    student_table = "student_#{ adapter_literal }s".id
-    teacher_table = "teacher_#{ adapter_literal }s".id
-    klass_table = "klass_#{ adapter_literal }s".id
-    enrollment_table = "enrollment_#{ adapter_literal }s".id
-    school_table = "school_#{ adapter_literal }s".id
-    nation_county_table = "nation_county_#{ adapter_literal }s".id
+    parent_table = "parent_#{adapter_literal}s".id
+    student_table = "student_#{adapter_literal}s".id
+    teacher_table = "teacher_#{adapter_literal}s".id
+    klass_table = "klass_#{adapter_literal}s".id
+    enrollment_table = "enrollment_#{adapter_literal}s".id
+    school_table = "school_#{adapter_literal}s".id
+    nation_county_table = "nation_county_#{adapter_literal}s".id
+    review_table = "review_#{adapter_literal}s".id
 
     if adapter == "pg"
       primary_key_sql = "BIGSERIAL PRIMARY KEY".id
@@ -26,8 +27,8 @@ end
     elsif adapter == "mysql"
       primary_key_sql = "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
-      created_at_sql  = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,".id
-      updated_at_sql  = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,".id
+      created_at_sql = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,".id
+      updated_at_sql = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,".id
       timestamp_fields = "timestamps".id
     elsif adapter == "sqlite"
       primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
@@ -181,6 +182,34 @@ end
       end
     end
 
+    class Review{{ adapter_const_suffix }} < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name "{{ review_table }}"
+      field name : String
+      field downvotes : Int32
+      field upvotes : Int64
+      field sentiment : Float32
+      field interest : Float64
+      field published : Bool
+      field created_at : Time
+
+      def self.drop_and_create
+        exec "DROP TABLE IF EXISTS {{ review_table }}"
+        exec <<-SQL
+          CREATE TABLE {{ review_table }} (
+            id {{ primary_key_sql }},
+            name VARCHAR(255),
+            downvotes INT,
+            upvotes BIGINT,
+            sentiment FLOAT,
+            interest REAL,
+            published BOOL,
+            created_at TIMESTAMP
+          )
+        SQL
+      end
+    end
+
     module GraniteExample
       @@model_classes << Parent{{ adapter_const_suffix }}
       @@model_classes << Teacher{{ adapter_const_suffix }}
@@ -189,6 +218,7 @@ end
       @@model_classes << Enrollment{{ adapter_const_suffix }}
       @@model_classes << School{{ adapter_const_suffix }}
       @@model_classes << Nation::County{{ adapter_const_suffix }}
+      @@model_classes << Review{{ adapter_const_suffix }}
     end
 
     Spec.before_each do
@@ -199,6 +229,7 @@ end
       Enrollment{{ adapter_const_suffix }}.clear
       School{{ adapter_const_suffix }}.clear
       Nation::County{{ adapter_const_suffix }}.clear
+      Review{{ adapter_const_suffix }}.clear
     end
 
 {% end %}

--- a/src/granite_orm/error.cr
+++ b/src/granite_orm/error.cr
@@ -1,7 +1,7 @@
 class Granite::ORM::Error
   property field, message
 
-  def initialize(@field : Symbol, @message : String)
+  def initialize(@field : (String | Symbol), @message : String?)
   end
 
   def to_s

--- a/src/granite_orm/error.cr
+++ b/src/granite_orm/error.cr
@@ -1,7 +1,7 @@
 class Granite::ORM::Error
   property field, message
 
-  def initialize(@field : (String | Symbol), @message : String?)
+  def initialize(@field : (String | Symbol), @message : String? = "")
   end
 
   def to_s

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -140,6 +140,8 @@ module Granite::ORM::Fields
           {% end %}
         {% end %}
       end
+    rescue ex
+      errors << Granite::ORM::Error.new(name, ex.message)
     end
   end
 end


### PR DESCRIPTION
This change catches any casting errors and adds it to the `errors` instead of throwing an exception.  It addresses issue #99 