### PR TITLE
underscore instead of downcase

### DIFF
--- a/spec/granite_orm/table/table_spec.cr
+++ b/spec/granite_orm/table/table_spec.cr
@@ -1,0 +1,34 @@
+require "../../spec_helper"
+
+class SongThread < Granite::ORM::Base
+  adapter pg
+  field name : String
+end
+
+class CustomSongThread < Granite::ORM::Base
+  adapter pg
+  table_name custom_table_name
+  primary custom_primary_key : Int64
+  field name : String
+end
+
+describe Granite::ORM::Table do
+  describe "#table_name" do
+    it "sets the table name to name specified" do
+      CustomSongThread.table_name.should eq "custom_table_name"
+    end
+
+    it "sets the table name based on class name if not specified" do
+      SongThread.table_name.should eq "song_threads"
+    end
+  end
+
+  describe "#primary" do
+    it "sets the primary key name to name specified" do
+      CustomSongThread.primary_name.should eq "custom_primary_key"
+    end
+    it "sets the primary key name to id if not specified" do
+      SongThread.primary_name.should eq "id"
+    end
+  end
+end

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -32,20 +32,18 @@ module Granite::ORM::Table
     {% table_name = SETTINGS[:table_name] || name_space + "s" %}
     {% primary_name = PRIMARY[:name] %}
     {% primary_type = PRIMARY[:type] %}
-    # Table Name
+
     @@table_name = "{{table_name}}"
-    
+    @@primary_name = "{{primary_name}}"
+
+    property {{primary_name}} : Union({{primary_type.id}} | Nil)
+
     def self.table_name
       @@table_name
     end
 
-    @@primary_name = "{{primary_name}}"
-
     def self.primary_name
       @@primary_name
     end
-
-    # Create the primary key
-    property {{primary_name}} : Union({{primary_type.id}} | Nil)
   end
 end

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -34,7 +34,17 @@ module Granite::ORM::Table
     {% primary_type = PRIMARY[:type] %}
     # Table Name
     @@table_name = "{{table_name}}"
+    
+    def self.table_name
+      @@table_name
+    end
+
     @@primary_name = "{{primary_name}}"
+
+    def self.primary_name
+      @@primary_name
+    end
+
     # Create the primary key
     property {{primary_name}} : Union({{primary_type.id}} | Nil)
   end

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -28,7 +28,7 @@ module Granite::ORM::Table
   end
 
   macro __process_table
-    {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
+    {% name_space = @type.name.gsub(/::/, "_").underscore.id %}
     {% table_name = SETTINGS[:table_name] || name_space + "s" %}
     {% primary_name = PRIMARY[:name] %}
     {% primary_type = PRIMARY[:type] %}


### PR DESCRIPTION
This fixes the original issue #76 with naming convention for tables that @marksiemers suggested

