### PR TITLE
Implement both validate syntax (blocks and procs)

### DIFF
--- a/spec/granite_orm_spec.cr
+++ b/spec/granite_orm_spec.cr
@@ -6,6 +6,10 @@ class Todo < Granite::ORM::Base
   field name : String
   field priority : Int32
   timestamps
+
+  validate :name, "Name cannot be blank", ->(todo : Todo) do
+    !todo.name.to_s.blank?
+  end
 end
 
 class Review < Granite::ORM::Base
@@ -25,7 +29,7 @@ class WebSite < Granite::ORM::Base
   field name : String
 
   validate :name, "Name cannot be blank" do
-    !(name.not_nil!.blank?)
+    !name.to_s.blank?
   end
 end
 
@@ -111,7 +115,23 @@ describe Granite::ORM::Base do
   end
 
   describe "validating fields" do
-    context "without a name" do
+    context "using validate procs" do
+      it "is not valid" do
+        t = Todo.new(name: "", priority: 0)
+
+        t.valid?.should eq false
+        t.errors.first.message.should eq "Name cannot be blank"
+      end
+
+      it "is valid" do
+        t = Todo.new(name: "Fix issues", priority: 0)
+
+        t.valid?.should eq true
+        t.errors.empty?.should eq true
+      end
+    end
+
+    context "using validate blocks" do
       it "is not valid" do
         s = WebSite.new(name: "")
 

--- a/src/granite_orm/validators.cr
+++ b/src/granite_orm/validators.cr
@@ -5,12 +5,23 @@ module Granite::ORM::Validators
 
   macro included
     macro inherited
+      @@validators = Array({field: Symbol, message: String, block: Proc(self, Bool)}).new
       @validators = Array({field: Symbol, message: String, block: Proc(Bool)}).new
       def validate!
       end
     end
   end
 
+  # First option: syntax support using procs
+  macro validate(message, block)
+    @@validators << {field: :base, message: {{message}}, block: {{block}}}
+  end
+
+  macro validate(field, message, block)
+    @@validators << {field: {{field}}, message: {{message}}, block: {{block}}}
+  end
+
+  # Second option: syntax sypport using blocks
   macro validate(message)
     def validate!
       previous_def
@@ -25,7 +36,25 @@ module Granite::ORM::Validators
     end
   end
 
+  # Analyze validation blocks and procs
+  # Note: This method checks two type of validation macros
+  #
+  # By example:
+  # ```
+  # validate :name, "name can't be blank" do
+  #   !name.to_s.blank?
+  # end
+  #
+  # validate :name, "name can't be blank", -> (user : User) do
+  #   !user.name.to_s.blank?
+  # end
+  # ```
   def valid?
+    @@validators.each do |validator|
+      unless validator[:block].call(self)
+        error << Error.new(validator[:field], validator[:message])
+      end
+    end
     validate!
     @validators.each do |validator|
       unless validator[:block].call

--- a/src/granite_orm/validators.cr
+++ b/src/granite_orm/validators.cr
@@ -52,7 +52,7 @@ module Granite::ORM::Validators
   def valid?
     @@validators.each do |validator|
       unless validator[:block].call(self)
-        error << Error.new(validator[:field], validator[:message])
+        errors << Error.new(validator[:field], validator[:message])
       end
     end
     validate!


### PR DESCRIPTION
> lets see if we can support both syntaxes for the validation in Granite. That will fix this and avoid a breaking change.

This PR implements the idea commented by @drujensen 

Required by: https://github.com/amberframework/amber/pull/588