### PR TITLE
parse timestamp strings for sqlite db adapter

### DIFF
--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -34,9 +34,9 @@ end
     elsif adapter == "sqlite"
       primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
       foreign_key_sql = "INTEGER".id
-      created_at_sql = "".id
-      updated_at_sql = "".id
-      timestamp_fields = "".id
+      created_at_sql = "created_at VARCHAR,".id
+      updated_at_sql = "updated_at VARCHAR,".id
+      timestamp_fields = "timestamps".id
     end
   %}
 
@@ -52,7 +52,7 @@ end
 
       has_many :student_{{ adapter_literal }}s
 
-      validate :name, "Name cannot be blank" do |parent| 
+      validate :name, "Name cannot be blank" do |parent|
         !parent.name.to_s.blank?
       end
 
@@ -209,7 +209,8 @@ end
             sentiment FLOAT,
             interest REAL,
             published BOOL,
-            created_at TIMESTAMP
+            {{ created_at_sql }}
+            {{ updated_at_sql }}
           )
         SQL
       end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -10,20 +10,20 @@ end
     if adapter == "pg"
       primary_key_sql = "BIGSERIAL PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
-      created_at_sql = "created_at TIMESTAMP,".id
-      updated_at_sql = "updated_at TIMESTAMP,".id
+      created_at_sql = "created_at TIMESTAMP".id
+      updated_at_sql = "updated_at TIMESTAMP".id
       timestamp_fields = "timestamps".id
     elsif adapter == "mysql"
       primary_key_sql = "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
-      created_at_sql = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,".id
-      updated_at_sql = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,".id
+      created_at_sql = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP".id
+      updated_at_sql = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP".id
       timestamp_fields = "timestamps".id
     elsif adapter == "sqlite"
       primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
       foreign_key_sql = "INTEGER".id
-      created_at_sql = "created_at VARCHAR,".id
-      updated_at_sql = "updated_at VARCHAR,".id
+      created_at_sql = "created_at VARCHAR".id
+      updated_at_sql = "updated_at VARCHAR".id
       timestamp_fields = "timestamps".id
     end
   %}
@@ -49,9 +49,9 @@ end
         exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
         exec("CREATE TABLE #{ quoted_table_name } (
           id {{ primary_key_sql }},
-          {{ created_at_sql }}
+          name VARCHAR(100),
+          {{ created_at_sql }},
           {{ updated_at_sql }}
-          name VARCHAR(100)
         );
         ")
       end
@@ -198,7 +198,7 @@ end
             sentiment FLOAT,
             interest REAL,
             published BOOL,
-            {{ created_at_sql }}
+            {{ created_at_sql }},
             {{ updated_at_sql }}
           )
         SQL

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -15,8 +15,15 @@ module Granite::ORM::Querying
         \{% end %}
 
         \{% if SETTINGS[:timestamps] %}
-          model.created_at = result.read(Union(Time | Nil))
-          model.updated_at = result.read(Union(Time | Nil))
+         if @@adapter.class.name == "Granite::Adapter::Sqlite"
+            # sqlite3 does not have timestamp type - timestamps are stored as strings
+            # will break for null timestamps
+            model.created_at = Time.parse(result.read(String), "%F %X" )
+            model.updated_at = Time.parse(result.read(String), "%F %X" )
+          else
+            model.created_at = result.read(Union(Time | Nil))
+            model.updated_at = result.read(Union(Time | Nil))
+          end
         \{% end %}
         return model
       end


### PR DESCRIPTION
A quick simple fix to handle created_at/updated_at when using sqlite database adapter, however the values must be populated (which should be the case if the timestamps settings value has been enabled)