### PR TITLE
add belongs_to custom type support

### DIFF
--- a/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
+++ b/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
@@ -1,0 +1,54 @@
+require "../../spec_helper"
+
+class Tool < Granite::ORM::Base
+  adapter pg
+  has_many :tool_reviews
+
+  primary id : Int32
+  field name : String
+
+  def self.drop_and_create
+    exec("DROP TABLE IF EXISTS tools;")
+    exec("CREATE TABLE tools (
+        id SERIAL PRIMARY KEY,
+        name VARCHAR(100)
+      );
+    ")
+  end
+end
+
+class ToolReview < Granite::ORM::Base
+  adapter pg
+  belongs_to :tool, tool_id : Int32
+
+  primary id : Int32
+  field body : String
+
+  def self.drop_and_create
+    exec("DROP TABLE IF EXISTS tool_reviews;")
+    exec("CREATE TABLE tool_reviews (
+        id SERIAL PRIMARY KEY,
+        tool_id INTEGER,
+        body VARCHAR(100)
+      );
+    ")
+  end
+end
+
+describe "belongs_to" do
+  it "supports custom types for the join" do
+    Tool.drop_and_create
+    ToolReview.drop_and_create
+
+    tool = Tool.new
+    tool.name = "Screw driver"
+    tool.save
+
+    review = ToolReview.new
+    review.tool = tool
+    review.body = "Best tool ever!"
+    review.save
+
+    review.tool.name.should eq "Screw driver"
+  end
+end

--- a/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
+++ b/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
@@ -1,54 +1,20 @@
 require "../../spec_helper"
 
-class Tool < Granite::ORM::Base
-  adapter pg
-  has_many :tool_reviews
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} belongs_to" do
+    it "supports custom types for the join" do
+      tool = Tool.new
+      tool.name = "Screw driver"
+      tool.save
 
-  primary id : Int32
-  field name : String
+      review = ToolReview.new
+      review.tool = tool
+      review.body = "Best tool ever!"
+      review.save
 
-  def self.drop_and_create
-    exec("DROP TABLE IF EXISTS tools;")
-    exec("CREATE TABLE tools (
-        id SERIAL PRIMARY KEY,
-        name VARCHAR(100)
-      );
-    ")
+      review.tool.name.should eq "Screw driver"
+    end
   end
 end
-
-class ToolReview < Granite::ORM::Base
-  adapter pg
-  belongs_to :tool, tool_id : Int32
-
-  primary id : Int32
-  field body : String
-
-  def self.drop_and_create
-    exec("DROP TABLE IF EXISTS tool_reviews;")
-    exec("CREATE TABLE tool_reviews (
-        id SERIAL PRIMARY KEY,
-        tool_id INTEGER,
-        body VARCHAR(100)
-      );
-    ")
-  end
-end
-
-describe "belongs_to" do
-  it "supports custom types for the join" do
-    Tool.drop_and_create
-    ToolReview.drop_and_create
-
-    tool = Tool.new
-    tool.name = "Screw driver"
-    tool.save
-
-    review = ToolReview.new
-    review.tool = tool
-    review.body = "Best tool ever!"
-    review.save
-
-    review.tool.name.should eq "Screw driver"
-  end
-end
+{% end %}

--- a/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
+++ b/spec/granite_orm/associations/belongs_to_custom_type_spec.cr
@@ -4,16 +4,16 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} belongs_to" do
     it "supports custom types for the join" do
-      tool = Tool.new
-      tool.name = "Screw driver"
-      tool.save
+      book = Book.new
+      book.name = "Screw driver"
+      book.save
 
-      review = ToolReview.new
-      review.tool = tool
-      review.body = "Best tool ever!"
+      review = BookReview.new
+      review.book = book
+      review.body = "Best book ever!"
       review.save
 
-      review.tool.name.should eq "Screw driver"
+      review.book.name.should eq "Screw driver"
     end
   end
 end

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -41,7 +41,7 @@ end
 
       has_many :students
 
-      validate :name, "Name cannot be blank" do |parent| 
+      validate :name, "Name cannot be blank" do |parent|
         !parent.name.to_s.blank?
       end
 
@@ -278,6 +278,41 @@ end
       end
     end
 
+    class Tool < Granite::ORM::Base
+      adapter pg
+      has_many :tool_reviews
+
+      primary id : Int32
+      field name : String
+
+      def self.drop_and_create
+        exec("DROP TABLE IF EXISTS tools;")
+        exec("CREATE TABLE tools (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(100)
+          );
+        ")
+      end
+    end
+
+    class ToolReview < Granite::ORM::Base
+      adapter pg
+      belongs_to :tool, tool_id : Int32
+
+      primary id : Int32
+      field body : String
+
+      def self.drop_and_create
+        exec("DROP TABLE IF EXISTS tool_reviews;")
+        exec("CREATE TABLE tool_reviews (
+            id SERIAL PRIMARY KEY,
+            tool_id INTEGER,
+            body VARCHAR(100)
+          );
+        ")
+      end
+    end
+
     Parent.drop_and_create
     Teacher.drop_and_create
     Student.drop_and_create
@@ -290,5 +325,7 @@ end
     ReservedWord.drop_and_create
     Callback.drop_and_create
     Kvs.drop_and_create
+    Tool.drop_and_create
+    ToolReview.drop_and_create
   end
 {% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -10,18 +10,24 @@ end
     if adapter == "pg"
       primary_key_sql = "BIGSERIAL PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
+      custom_primary_key_sql = "SERIAL PRIMARY KEY".id
+      custom_foreign_key_sql = "INT".id
       created_at_sql = "created_at TIMESTAMP,".id
       updated_at_sql = "updated_at TIMESTAMP,".id
       timestamp_fields = "timestamps".id
     elsif adapter == "mysql"
       primary_key_sql = "BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
       foreign_key_sql = "BIGINT".id
+      custom_primary_key_sql = "INT NOT NULL AUTO_INCREMENT PRIMARY KEY".id
+      custom_foreign_key_sql = "INT".id
       created_at_sql = "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,".id
       updated_at_sql = "updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,".id
       timestamp_fields = "timestamps".id
     elsif adapter == "sqlite"
       primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
       foreign_key_sql = "INTEGER".id
+      custom_primary_key_sql = "INTEGER NOT NULL PRIMARY KEY".id
+      custom_foreign_key_sql = "INTEGER".id
       created_at_sql = "".id
       updated_at_sql = "".id
       timestamp_fields = "".id
@@ -278,38 +284,42 @@ end
       end
     end
 
-    class Tool < Granite::ORM::Base
-      adapter pg
-      has_many :tool_reviews
+    class Book < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name books
+      has_many :book_reviews
 
       primary id : Int32
       field name : String
 
       def self.drop_and_create
-        exec("DROP TABLE IF EXISTS tools;")
-        exec("CREATE TABLE tools (
-            id SERIAL PRIMARY KEY,
-            name VARCHAR(100)
-          );
-        ")
+        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
+        exec <<-SQL
+          CREATE TABLE #{ quoted_table_name } (
+            id {{ custom_primary_key_sql }},
+            name VARCHAR(255)
+          )
+        SQL
       end
     end
 
-    class ToolReview < Granite::ORM::Base
-      adapter pg
-      belongs_to :tool, tool_id : Int32
+    class BookReview < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name book_reviews
+      belongs_to :book, book_id : Int32
 
       primary id : Int32
       field body : String
 
       def self.drop_and_create
-        exec("DROP TABLE IF EXISTS tool_reviews;")
-        exec("CREATE TABLE tool_reviews (
-            id SERIAL PRIMARY KEY,
-            tool_id INTEGER,
-            body VARCHAR(100)
-          );
-        ")
+        exec("DROP TABLE IF EXISTS #{ quoted_table_name };")
+        exec <<-SQL
+          CREATE TABLE #{ quoted_table_name } (
+            id {{ custom_primary_key_sql }},
+            book_id {{ custom_foreign_key_sql }},
+            body VARCHAR(255)
+          )
+        SQL
       end
     end
 
@@ -325,7 +335,7 @@ end
     ReservedWord.drop_and_create
     Callback.drop_and_create
     Kvs.drop_and_create
-    Tool.drop_and_create
-    ToolReview.drop_and_create
+    Book.drop_and_create
+    BookReview.drop_and_create
   end
 {% end %}

--- a/src/granite_orm/associations.cr
+++ b/src/granite_orm/associations.cr
@@ -1,7 +1,11 @@
 module Granite::ORM::Associations
   # define getter and setter for parent relationship
   macro belongs_to(model_name)
-    field {{model_name.id}}_id : Int64
+    belongs_to {{model_name}}, {{model_name.id}}_id : Int64
+  end
+
+  macro belongs_to(model_name, decl)
+    field {{decl.var}} : {{decl.type}}
 
     # retrieve the parent relationship
     def {{model_name.id}}


### PR DESCRIPTION
This allows you to specify a custom name and type for the `belongs_to` foreign key.   I needed this for backward compatibility with a rails project that has Int(11) in mysql.
```
belongs_to :tool, tool_id : Int32
```

This does not address the `has_many` relationship.