### PR TITLE
Fields are now required in default. Use `foo?` for nilable fields.

### DIFF
--- a/spec/granite_orm/fields/timestamps_spec.cr
+++ b/spec/granite_orm/fields/timestamps_spec.cr
@@ -18,8 +18,8 @@ require "../../spec_helper"
       parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
       found_parent = {{ parent_constant }}.find(parent.id).not_nil!
 
-      original_timestamp = parent.created_at.not_nil!
-      read_timestamp = found_parent.created_at.not_nil!
+      original_timestamp = parent.created_at
+      read_timestamp = found_parent.created_at
 
       original_timestamp.kind.should eq Time::Kind::Utc
       read_timestamp.kind.should eq {{ time_kind_on_read }}
@@ -29,8 +29,8 @@ require "../../spec_helper"
       parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
       found_parent = {{ parent_constant }}.find(parent.id).not_nil!
 
-      original_timestamp = parent.updated_at.not_nil!
-      read_timestamp = found_parent.updated_at.not_nil!
+      original_timestamp = parent.updated_at
+      read_timestamp = found_parent.updated_at
 
       original_timestamp.kind.should eq Time::Kind::Utc
       read_timestamp.kind.should eq {{ time_kind_on_read }}
@@ -40,8 +40,8 @@ require "../../spec_helper"
       parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
       found_parent = {{ parent_constant }}.find(parent.id).not_nil!
 
-      original_timestamp = parent.created_at.not_nil!
-      read_timestamp = found_parent.created_at.not_nil!
+      original_timestamp = parent.created_at
+      read_timestamp = found_parent.created_at
 
       original_timestamp.epoch.should eq read_timestamp.epoch
     end
@@ -50,8 +50,8 @@ require "../../spec_helper"
       parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
       found_parent = {{ parent_constant }}.find(parent.id).not_nil!
 
-      original_timestamp = parent.updated_at.not_nil!
-      read_timestamp = found_parent.updated_at.not_nil!
+      original_timestamp = parent.updated_at
+      read_timestamp = found_parent.updated_at
 
       original_timestamp.epoch.should eq read_timestamp.epoch
     end

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -19,7 +19,7 @@ require "../../spec_helper"
       parent = {{ parent_constant }}.new
       parent.name = ""
       parent.save
-      parent.id.should be_nil
+      parent.id?.should be_nil
     end
 
     it "updates an existing object" do

--- a/src/granite_orm/associations.cr
+++ b/src/granite_orm/associations.cr
@@ -5,7 +5,7 @@ module Granite::ORM::Associations
 
     # retrieve the parent relationship
     def {{model_name.id}}
-      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
+      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id?
         parent
       else
         {{model_name.id.camelcase}}.new
@@ -23,7 +23,7 @@ module Granite::ORM::Associations
       {% children_class = children_table.id[0...-1].camelcase %}
       {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
       {% table_name = SETTINGS[:table_name] || name_space + "s" %}
-      return [] of {{children_class}} unless id
+      return [] of {{children_class}} unless id?
       foreign_key = "{{children_table.id}}.{{table_name[0...-1]}}_id"
       query = "WHERE #{foreign_key} = ?"
       {{children_class}}.all(query, id)
@@ -36,7 +36,7 @@ module Granite::ORM::Associations
       {% children_class = children_table.id[0...-1].camelcase %}
       {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
       {% table_name = SETTINGS[:table_name] || name_space + "s" %}
-      return [] of {{children_class}} unless id
+      return [] of {{children_class}} unless id?
       query = "JOIN {{through.id}} ON {{through.id}}.{{children_table.id[0...-1]}}_id = {{children_table.id}}.id "
       query = query + "WHERE {{through.id}}.{{table_name[0...-1]}}_id = ?"
       {{children_class}}.all(query, id)

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -23,11 +23,21 @@ module Granite::ORM::Fields
   macro __process_fields
     # Create the properties
     {% for name, type in FIELDS %}
-      property {{name.id}} : Union({{type.id}} | Nil)
+      property? {{name.id}} : Union({{type.id}} | Nil)
+      def {{name.id}}
+        raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
+        @{{name.id}}.not_nil!
+      end
     {% end %}
     {% if SETTINGS[:timestamps] %}
-      property created_at : Time?
-      property updated_at : Time?
+      property? created_at : Time?
+      property? updated_at : Time?
+      {% for name in %w( created_at updated_at ) %}
+        def {{name.id}}
+          raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
+          @{{name.id}}.not_nil!
+        end
+      {% end %}
     {% end %}
 
     # keep a hash of the fields to be used for mapping
@@ -47,14 +57,14 @@ module Granite::ORM::Fields
       parsed_params = [] of DB::Any
       {% for name, type in FIELDS %}
         {% if type.id == Time.id %}
-          parsed_params << {{name.id}}.try(&.to_s("%F %X"))
+          parsed_params << {{name.id}}?.try(&.to_s("%F %X"))
         {% else %}
-          parsed_params << {{name.id}}
+          parsed_params << {{name.id}}?
         {% end %}
       {% end %}
       {% if SETTINGS[:timestamps] %}
-        parsed_params << created_at.not_nil!.to_s("%F %X")
-        parsed_params << updated_at.not_nil!.to_s("%F %X")
+        parsed_params << created_at.to_s("%F %X")
+        parsed_params << updated_at.to_s("%F %X")
       {% end %}
       return parsed_params
     end
@@ -62,20 +72,20 @@ module Granite::ORM::Fields
     def to_h
       fields = {} of String => DB::Any
 
-      fields["{{PRIMARY[:name]}}"] = {{PRIMARY[:name]}}
+      fields["{{PRIMARY[:name]}}"] = {{PRIMARY[:name]}}?
 
       {% for name, type in FIELDS %}
         {% if type.id == Time.id %}
-          fields["{{name}}"] = {{name.id}}.try(&.to_s("%F %X"))
+          fields["{{name}}"] = {{name.id}}?.try(&.to_s("%F %X"))
         {% elsif type.id == Slice.id %}
-          fields["{{name}}"] = {{name.id}}.try(&.to_s(""))
+          fields["{{name}}"] = {{name.id}}?.try(&.to_s(""))
         {% else %}
-          fields["{{name}}"] = {{name.id}}
+          fields["{{name}}"] = {{name.id}}?
         {% end %}
       {% end %}
       {% if SETTINGS[:timestamps] %}
-        fields["created_at"] = created_at.try(&.to_s("%F %X"))
-        fields["updated_at"] = updated_at.try(&.to_s("%F %X"))
+        fields["created_at"] = created_at?.try(&.to_s("%F %X"))
+        fields["updated_at"] = updated_at?.try(&.to_s("%F %X"))
       {% end %}
 
       return fields
@@ -83,10 +93,10 @@ module Granite::ORM::Fields
 
     def to_json(json : JSON::Builder)
       json.object do
-        json.field "{{PRIMARY[:name]}}", {{PRIMARY[:name]}}
+        json.field "{{PRIMARY[:name]}}", {{PRIMARY[:name]}}?
 
         {% for name, type in FIELDS %}
-          %field, %value = "{{name.id}}", {{name.id}}
+          %field, %value = "{{name.id}}", {{name.id}}?
           {% if type.id == Time.id %}
             json.field %field, %value.try(&.to_s("%F %X"))
           {% elsif type.id == Slice.id %}
@@ -97,8 +107,8 @@ module Granite::ORM::Fields
         {% end %}
 
         {% if SETTINGS[:timestamps] %}
-          json.field "created_at", created_at.try(&.to_s("%F %X"))
-          json.field "updated_at", updated_at.try(&.to_s("%F %X"))
+          json.field "created_at", created_at?.try(&.to_s("%F %X"))
+          json.field "updated_at", updated_at?.try(&.to_s("%F %X"))
         {% end %}
       end
     end

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -36,7 +36,12 @@ module Granite::ORM::Table
     @@table_name = "{{table_name}}"
     @@primary_name = "{{primary_name}}"
 
-    property {{primary_name}} : Union({{primary_type.id}} | Nil)
+    property? {{primary_name}} : Union({{primary_type.id}} | Nil)
+
+    def {{primary_name}}
+      raise {{@type.name.stringify}} + "#" + {{primary_name.stringify}} + " cannot be nil" if @{{primary_name}}.nil?
+      @{{primary_name}}.not_nil!
+    end
 
     def self.table_name
       @@table_name


### PR DESCRIPTION
In this PR, field requires values ​​by default, otherwise raises the proper missing exceptions.
Now, users can avoid the redundant `not_nil!`, and also can use `foo?` for the nilable cases.

```crystal

user = User.new(name: "maiha")
user.name? # => "maiha"
user.name  # => "maiha"

user = User.new
user.name? # => nil
user.name  # => User#name cannot be nil (Exception)
```

Best regards,