### PR TITLE
simplify specs by reducing macros

### DIFF
--- a/spec/granite_orm/associations/belongs_to_spec.cr
+++ b/spec/granite_orm/associations/belongs_to_spec.cr
@@ -1,39 +1,33 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    teacher_constant = "Teacher#{adapter.camelcase.id}".id
-    klass_constant = "Klass#{adapter.camelcase.id}".id
-
-    adapter_suffix = "_#{adapter.id}".id
-  %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} belongs_to" do
     it "provides a getter for the foreign entity" do
-      teacher = {{ teacher_constant }}.new
+      teacher = Teacher.new
       teacher.name = "Test teacher"
       teacher.save
 
-      klass = {{ klass_constant }}.new
+      klass = Klass.new
       klass.name = "Test klass"
-      klass.teacher{{ adapter_suffix }}_id = teacher.id
+      klass.teacher_id = teacher.id
       klass.save
 
-      klass.teacher{{ adapter_suffix }}.id.should eq teacher.id
+      klass.teacher.id.should eq teacher.id
     end
 
     it "provides a setter for the foreign entity" do
-      teacher = {{ teacher_constant }}.new
+      teacher = Teacher.new
       teacher.name = "Test teacher"
       teacher.save
 
-      klass = {{ klass_constant }}.new
+      klass = Klass.new
       klass.name = "Test klass"
-      klass.teacher{{ adapter_suffix }} = teacher
+      klass.teacher = teacher
       klass.save
 
-      klass.teacher{{ adapter_suffix }}_id.should eq teacher.id
+      klass.teacher_id.should eq teacher.id
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/associations/has_many_spec.cr
+++ b/spec/granite_orm/associations/has_many_spec.cr
@@ -1,80 +1,72 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    teacher_constant    = "Teacher#{adapter.camelcase.id}".id
-    klass_constant      = "Klass#{adapter.camelcase.id}".id
-    student_constant    = "Student#{adapter.camelcase.id}".id
-    enrollment_constant = "Enrollment#{adapter.camelcase.id}".id
-
-    adapter_suffix = "_#{adapter.id}".id
-  %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} has_many" do
     it "provides a method to retrieve associated objects" do
-      teacher = {{ teacher_constant }}.new
+      teacher = Teacher.new
       teacher.name = "test teacher"
       teacher.save
 
-      class1 = {{ klass_constant }}.new
+      class1 = Klass.new
       class1.name = "Test class 1"
-      class1.teacher{{ adapter_suffix }} = teacher
+      class1.teacher = teacher
       class1.save
 
-      class2 = {{ klass_constant }}.new
+      class2 = Klass.new
       class2.name = "Test class 2"
-      class2.teacher{{ adapter_suffix }} = teacher
+      class2.teacher = teacher
       class2.save
 
-      class3 = {{ klass_constant }}.new
+      class3 = Klass.new
       class3.name = "Test class 3"
       class3.save
 
-      teacher.klass{{ adapter_suffix }}s.size.should eq 2
+      teacher.klasss.size.should eq 2
     end
 
     describe "#has_many, through:" do
       it "provides a method to retrieve associated objects through another table" do
-        student = {{ student_constant }}.new
+        student = Student.new
         student.name = "test student"
         student.save
 
-        unrelated_student = {{ student_constant }}.new
+        unrelated_student = Student.new
         unrelated_student.name = "other student"
         unrelated_student.save
 
-        klass1 = {{ klass_constant }}.new
+        klass1 = Klass.new
         klass1.name = "Test class"
         klass1.save
 
-        klass2 = {{ klass_constant }}.new
+        klass2 = Klass.new
         klass2.name = "Test class"
         klass2.save
 
-        klass3 = {{ klass_constant }}.new
+        klass3 = Klass.new
         klass3.name = "Test class"
         klass3.save
 
-        enrollment1 = {{ enrollment_constant }}.new
-        enrollment1.student{{ adapter_suffix }} = student
-        enrollment1.klass{{ adapter_suffix }} = klass1
+        enrollment1 = Enrollment.new
+        enrollment1.student = student
+        enrollment1.klass = klass1
         enrollment1.save
 
-        enrollment2 = {{ enrollment_constant }}.new
-        enrollment2.student{{ adapter_suffix }} = student
-        enrollment2.klass{{ adapter_suffix }} = klass2
+        enrollment2 = Enrollment.new
+        enrollment2.student = student
+        enrollment2.klass = klass2
         enrollment2.save
 
-        enrollment3 = {{ enrollment_constant }}.new
-        enrollment3.klass{{ adapter_suffix }} = klass2
-        enrollment3.student{{ adapter_suffix }} = unrelated_student
+        enrollment3 = Enrollment.new
+        enrollment3.klass = klass2
+        enrollment3.student = unrelated_student
         enrollment3.save
 
-        student.klass{{ adapter_suffix }}s.map(&.id).compact.sort.should eq [klass1.id, klass2.id].compact.sort
+        student.klasss.map(&.id).compact.sort.should eq [klass1.id, klass2.id].compact.sort
 
-        klass2.student{{ adapter_suffix }}s.map(&.id).compact.sort.should eq [student.id, unrelated_student.id].compact.sort
+        klass2.students.map(&.id).compact.sort.should eq [student.id, unrelated_student.id].compact.sort
       end
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/fields/casting_spec.cr
+++ b/spec/granite_orm/fields/casting_spec.cr
@@ -1,21 +1,20 @@
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Review#{adapter.camelcase.id}".id %}
-  {% empty_model_constant = "Empty#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #casting_to_fields" do
     it "casts string to int" do
-      model = {{ model_constant }}.new({ "downvotes" => "32" })
+      model = Review.new({ "downvotes" => "32" })
       model.downvotes.should eq 32
     end
 
     it "generates an error if casting fails" do
-      model = {{ model_constant }}.new({ "downvotes" => "" })
+      model = Review.new({ "downvotes" => "" })
       model.errors.size.should eq 1
     end
 
     it "compiles with empty fields" do
-      model = {{ empty_model_constant }}.new
+      model = Empty.new
       model.should_not be_nil
     end
   end
+end
 {% end %}

--- a/spec/granite_orm/fields/timestamps_spec.cr
+++ b/spec/granite_orm/fields/timestamps_spec.cr
@@ -2,9 +2,10 @@ require "../../spec_helper"
 
 # TODO sqlite support for timestamps
 {% for adapter in ["pg", "mysql"] %}
+module {{adapter.capitalize.id}}
   {%
-    parent_constant = "Parent#{adapter.camelcase.id}".id
-
+    avoid_macro_bug = 1 # https://github.com/crystal-lang/crystal/issues/5724
+    
     # TODO mysql timestamp support should work better
     if adapter == "pg"
       time_kind_on_read = "Time::Kind::Utc".id
@@ -15,8 +16,8 @@ require "../../spec_helper"
 
   describe "{{ adapter.id }} timestamps" do
     it "consistently uses UTC for created_at" do
-      parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
-      found_parent = {{ parent_constant }}.find(parent.id).not_nil!
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find(parent.id).not_nil!
 
       original_timestamp = parent.created_at
       read_timestamp = found_parent.created_at
@@ -26,8 +27,8 @@ require "../../spec_helper"
     end
 
     it "consistently uses UTC for updated_at" do
-      parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
-      found_parent = {{ parent_constant }}.find(parent.id).not_nil!
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find(parent.id).not_nil!
 
       original_timestamp = parent.updated_at
       read_timestamp = found_parent.updated_at
@@ -37,8 +38,8 @@ require "../../spec_helper"
     end
 
     it "truncates the subsecond parts of created_at" do
-      parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
-      found_parent = {{ parent_constant }}.find(parent.id).not_nil!
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find(parent.id).not_nil!
 
       original_timestamp = parent.created_at
       read_timestamp = found_parent.created_at
@@ -47,8 +48,8 @@ require "../../spec_helper"
     end
 
     it "truncates the subsecond parts of updated_at" do
-      parent = {{ parent_constant }}.new(name: "parent").tap(&.save)
-      found_parent = {{ parent_constant }}.find(parent.id).not_nil!
+      parent = Parent.new(name: "parent").tap(&.save)
+      found_parent = Parent.find(parent.id).not_nil!
 
       original_timestamp = parent.updated_at
       read_timestamp = found_parent.updated_at
@@ -56,4 +57,5 @@ require "../../spec_helper"
       original_timestamp.epoch.should eq read_timestamp.epoch
     end
   end
+end
 {% end %}

--- a/spec/granite_orm/querying/all_spec.cr
+++ b/spec/granite_orm/querying/all_spec.cr
@@ -1,15 +1,14 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #all" do
     it "finds all the records" do
       model_ids = (0...100).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
-      all = {{ model_constant }}.all
+      all = Parent.all
       all.size.should eq model_ids.size
       all.map(&.id).compact.sort.should eq model_ids.compact
     end
@@ -17,19 +16,19 @@ require "../../spec_helper"
     # TODO Fails under MySQL
     # it "finds records with numbered query substition" do
     #   name = "findable model"
-    #   model = {{ model_constant }}.new(name: name).tap(&.save)
-    #   set = {{ model_constant }}.all("WHERE name = $1", [name])
+    #   model = Parent.new(name: name).tap(&.save)
+    #   set = Parent.all("WHERE name = $1", [name])
     #   set.size.should eq 1
     #   set.first.name.should eq name
     # end
 
     it "finds records with question mark substition" do
       name = "findable model"
-      model = {{ model_constant }}.new(name: name).tap(&.save)
-      set = {{ model_constant }}.all("WHERE name = ?", [name])
+      model = Parent.new(name: name).tap(&.save)
+      set = Parent.all("WHERE name = ?", [name])
       set.size.should eq 1
       set.first.name.should eq name
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/count_spec.cr
+++ b/spec/granite_orm/querying/count_spec.cr
@@ -1,22 +1,21 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #count" do
     it "returns 0 if no result" do
-      count = {{ model_constant }}.count
+      count = Parent.count
       count.should eq 0
     end
 
     it "returns a number of the all records for the model" do
       2.times do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end
 
-      count = {{ model_constant }}.count
+      count = Parent.count
       count.should eq 2
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/find_by_spec.cr
+++ b/spec/granite_orm/querying/find_by_spec.cr
@@ -1,45 +1,43 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-  {% reserved_word_constant = "ReservedWord#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_by" do
     it "finds an object with a string field" do
       name = "robinson"
 
-      model = {{ model_constant }}.new
+      model = Parent.new
       model.name = name
       model.save
 
-      found = {{ model_constant }}.find_by("name", name)
+      found = Parent.find_by("name", name)
       found.not_nil!.id.should eq model.id
     end
 
     it "finds an object with a symbol field" do
       name = "robinson"
 
-      model = {{ model_constant }}.new
+      model = Parent.new
       model.name = name
       model.save
 
-      found = {{ model_constant }}.find_by(:name, name)
+      found = Parent.find_by(:name, name)
       found.not_nil!.id.should eq model.id
     end
 
     it "also works with reserved words" do
       value = "robinson"
 
-      model = {{ reserved_word_constant }}.new
+      model = ReservedWord.new
       model.all = value
       model.save
 
-      found = {{ reserved_word_constant }}.find_by("all", value)
+      found = ReservedWord.find_by("all", value)
       found.not_nil!.id.should eq model.id
 
-      found = {{ reserved_word_constant }}.find_by(:all, value)
+      found = ReservedWord.find_by(:all, value)
       found.not_nil!.id.should eq model.id
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/find_each_spec.cr
+++ b/spec/granite_orm/querying/find_each_spec.cr
@@ -1,16 +1,15 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_each" do
     it "finds all the records" do
       model_ids = (0...100).map do |i|
-        {{ model_constant }}.new(name: "role_#{i}").tap {|r| r.save }
+        Parent.new(name: "role_#{i}").tap {|r| r.save }
       end.map(&.id)
 
       found_roles = [] of Int64 | Nil
-      {{ model_constant }}.find_each do |model|
+      Parent.find_each do |model|
         found_roles << model.id
       end
 
@@ -18,14 +17,14 @@ require "../../spec_helper"
     end
 
     it "doesnt yield when no records are found" do
-      {{ model_constant }}.find_each do |model|
+      Parent.find_each do |model|
         fail "did yield"
       end
     end
 
     it "can start from an offset" do
       created_models = (0...10).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
       # discard the first two models
@@ -34,7 +33,7 @@ require "../../spec_helper"
 
       found_models = [] of Int64 | Nil
 
-      {{ model_constant }}.find_each(offset: 2) do |model|
+      Parent.find_each(offset: 2) do |model|
         found_models << model.id
       end
 
@@ -43,18 +42,18 @@ require "../../spec_helper"
 
     it "doesnt obliterate a parameterized query" do
       created_models = (0...10).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
       looking_for_ids = created_models[0...5]
 
       found_models = [] of Int64 | Nil
-      {{ model_constant }}.find_each("WHERE id IN(#{looking_for_ids.join(",")})") do |model|
+      Parent.find_each("WHERE id IN(#{looking_for_ids.join(",")})") do |model|
         found_models << model.id
       end
 
       found_models.compact.should eq looking_for_ids
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/find_in_batches.cr
+++ b/spec/granite_orm/querying/find_in_batches.cr
@@ -1,16 +1,15 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_in_batches" do
     it "finds records in batches and yields all the records" do
       model_ids = (0...100).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
       found_models = [] of Int32 | Nil
-      {{ model_constant }}.find_in_batches(batch_size: 10) do |batch|
+      Parent.find_in_batches(batch_size: 10) do |batch|
         batch.each { |model| found_models << model.id }
         batch.size.should eq 10
       end
@@ -19,14 +18,14 @@ require "../../spec_helper"
     end
 
     it "doesnt yield when no records are found" do
-      {{ model_constant }}.find_in_batches do |model|
+      Parent.find_in_batches do |model|
         fail "find_in_batches did yield but shouldn't have"
       end
     end
 
     it "errors when batch_size is < 1" do
       expect_raises ArgumentError do
-        {{ model_constant }}.find_in_batches batch_size: 0 do |model|
+        Parent.find_in_batches batch_size: 0 do |model|
           fail "should have raised"
         end
       end
@@ -34,17 +33,17 @@ require "../../spec_helper"
 
     it "returns a small batch when there arent enough results" do
       (0...9).each do |i|
-        {{ model_constant }}.new(name: "model_#{i}").save
+        Parent.new(name: "model_#{i}").save
       end
 
-      {{ model_constant }}.find_in_batches(batch_size: 11) do |batch|
+      Parent.find_in_batches(batch_size: 11) do |batch|
         batch.size.should eq 9
       end
     end
 
     it "can start from an offset other than 0" do
       created_models = (0...10).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
       # discard the first two models
@@ -53,7 +52,7 @@ require "../../spec_helper"
 
       found_models = [] of Int32 | Nil
 
-      {{ model_constant }}.find_in_batches(offset: 2) do |batch|
+      Parent.find_in_batches(offset: 2) do |batch|
         batch.each do |model|
           found_models << model.id
         end
@@ -64,15 +63,15 @@ require "../../spec_helper"
 
     it "doesnt obliterate a parameterized query" do
       created_models = (0...10).map do |i|
-        {{ model_constant }}.new(name: "model_#{i}").tap(&.save)
+        Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
 
       looking_for_ids = created_models[0...5]
 
-      {{ model_constant }}.find_in_batches("WHERE id IN(#{looking_for_ids.join(",")})") do |batch|
+      Parent.find_in_batches("WHERE id IN(#{looking_for_ids.join(",")})") do |batch|
         batch.map(&.id).compact.should eq looking_for_ids
       end
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/find_spec.cr
+++ b/spec/granite_orm/querying/find_spec.cr
@@ -1,46 +1,41 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    parent_constant = "Parent#{adapter.camelcase.id}".id
-    school_constant = "School#{adapter.camelcase.id}".id
-    nation_county_constant = "Nation::County#{adapter.camelcase.id}".id
-  %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find" do
     it "finds an object by id" do
-      model = {{ parent_constant }}.new
+      model = Parent.new
       model.name = "Test Comment"
       model.save
 
-      found = {{ parent_constant }}.find model.id
+      found = Parent.find model.id
       found.should_not be_nil
       found.not_nil!.id.should eq model.id
     end
 
     describe "with a custom primary key" do
       it "finds the object" do
-        school = {{ school_constant }}.new
+        school = School.new
         school.name = "Test School"
         school.save
         primary_key = school.custom_id
 
-        found_school = {{ school_constant }}.find primary_key
+        found_school = School.find primary_key
         found_school.should_not be_nil
       end
     end
 
     describe "with a modulized model" do
       it "finds the object" do
-        county = {{ nation_county_constant }}.new
+        county = Nation::County.new
         county.name = "Test County"
         county.save
         primary_key = county.id
 
-        found_county = {{ nation_county_constant }}.find primary_key
+        found_county = Nation::County.find primary_key
         found_county.should_not be_nil
       end
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/querying/first_spec.cr
+++ b/spec/granite_orm/querying/first_spec.cr
@@ -1,48 +1,47 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {% model_constant = "Parent#{adapter.camelcase.id}".id %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #first" do
     it "finds the first object" do
-      first = {{ model_constant }}.new.tap do |model|
+      first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
       end
 
-      second = {{ model_constant }}.new.tap do |model|
+      second = Parent.new.tap do |model|
         model.name = "Test 2"
         model.save
       end
 
-      found = {{ model_constant }}.first
+      found = Parent.first
       found.not_nil!.id.should eq first.id
     end
 
     it "supports a SQL clause" do
-      first = {{ model_constant }}.new.tap do |model|
+      first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
       end
 
-      second = {{ model_constant }}.new.tap do |model|
+      second = Parent.new.tap do |model|
         model.name = "Test 2"
         model.save
       end
 
-      found = {{ model_constant }}.first("ORDER BY id DESC")
+      found = Parent.first("ORDER BY id DESC")
       found.not_nil!.id.should eq second.id
     end
 
     it "returns nil if no result" do
-      first = {{ model_constant }}.new.tap do |model|
+      first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
       end
 
-      found = {{ model_constant }}.first("WHERE name = 'Test 2'")
+      found = Parent.first("WHERE name = 'Test 2'")
       found.should be nil
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/transactions/destroy_spec.cr
+++ b/spec/granite_orm/transactions/destroy_spec.cr
@@ -1,49 +1,44 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    parent_constant = "Parent#{adapter.camelcase.id}".id
-    school_constant = "School#{adapter.camelcase.id}".id
-    nation_county_constant = "Nation::County#{adapter.camelcase.id}".id
-  %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #destroy" do
     it "destroys an object" do
-      parent = {{ parent_constant }}.new
+      parent = Parent.new
       parent.name = "Test Parent"
       parent.save
 
       id = parent.id
       parent.destroy
-      found = {{ parent_constant }}.find id
+      found = Parent.find id
       found.should be_nil
     end
 
     describe "with a custom primary key" do
       it "destroys an object" do
-        school = {{ school_constant }}.new
+        school = School.new
         school.name = "Test School"
         school.save
         primary_key = school.custom_id
         school.destroy
 
-        found_school = {{ school_constant }}.find primary_key
+        found_school = School.find primary_key
         found_school.should be_nil
       end
     end
 
     describe "with a modulized model" do
       it "destroys an object" do
-        county = {{ nation_county_constant }}.new
+        county = Nation::County.new
         county.name = "Test County"
         county.save
         primary_key = county.id
         county.destroy
 
-        found_county = {{ nation_county_constant }}.find primary_key
+        found_county = Nation::County.find primary_key
         found_county.should be_nil
       end
     end
   end
-
+end
 {% end %}

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -1,55 +1,49 @@
 require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
-  {%
-    parent_constant = "Parent#{adapter.camelcase.id}".id
-    school_constant = "School#{adapter.camelcase.id}".id
-    nation_county_constant = "Nation::County#{adapter.camelcase.id}".id
-    reserved_word_constant = "ReservedWord#{adapter.camelcase.id}".id
-  %}
-
+module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #save" do
     it "creates a new object" do
-      parent = {{ parent_constant }}.new
+      parent = Parent.new
       parent.name = "Test Parent"
       parent.save
       parent.id.should_not be_nil
     end
 
     it "does not create an invalid object" do
-      parent = {{ parent_constant }}.new
+      parent = Parent.new
       parent.name = ""
       parent.save
       parent.id?.should be_nil
     end
 
     it "updates an existing object" do
-      parent = {{ parent_constant }}.new
+      parent = Parent.new
       parent.name = "Test Parent"
       parent.save
       parent.name = "Test Parent 2"
       parent.save
 
-      parents = {{ parent_constant }}.all
+      parents = Parent.all
       parents.size.should eq 1
 
-      found = {{ parent_constant }}.first
+      found = Parent.first
       found.not_nil!.name.should eq parent.name
     end
 
     it "does not update an invalid object" do
-      parent = {{ parent_constant }}.new
+      parent = Parent.new
       parent.name = "Test Parent"
       parent.save
       parent.name = ""
       parent.save
-      parent = {{ parent_constant }}.find parent.id
+      parent = Parent.find parent.id
       parent.not_nil!.name.should eq "Test Parent"
     end
 
     describe "with a custom primary key" do
       it "creates a new object" do
-        school = {{ school_constant }}.new
+        school = School.new
         school.name = "Test School"
         school.save
         school.custom_id.should_not be_nil
@@ -59,7 +53,7 @@ require "../../spec_helper"
         old_name = "Test School 1"
         new_name = "Test School 2"
 
-        school = {{ school_constant }}.new
+        school = School.new
         school.name = old_name
         school.save
 
@@ -68,7 +62,7 @@ require "../../spec_helper"
         school.name = new_name
         school.save
 
-        found_school = {{ school_constant }}.find primary_key
+        found_school = School.find primary_key
         found_school.not_nil!.custom_id.should eq primary_key
         found_school.not_nil!.name.should eq new_name
       end
@@ -76,7 +70,7 @@ require "../../spec_helper"
 
     describe "with a modulized model" do
       it "creates a new object" do
-        county = {{ nation_county_constant }}.new
+        county = Nation::County.new
         county.name = "Test School"
         county.save
         county.id.should_not be_nil
@@ -86,7 +80,7 @@ require "../../spec_helper"
         old_name = "Test County 1"
         new_name = "Test County 2"
 
-        county = {{ nation_county_constant }}.new
+        county = Nation::County.new
         county.name = old_name
         county.save
 
@@ -95,7 +89,7 @@ require "../../spec_helper"
         county.name = new_name
         county.save
 
-        found_county = {{ nation_county_constant }}.find primary_key
+        found_county = Nation::County.find primary_key
         found_county.not_nil!.name.should eq new_name
       end
     end
@@ -103,7 +97,7 @@ require "../../spec_helper"
     describe "using a reserved word as a column name" do
       # `all` is a reserved word in almost RDB like MySQL, PostgreSQL
       it "creates and updates" do
-        reserved_word = {{ reserved_word_constant }}.new
+        reserved_word = ReservedWord.new
         reserved_word.all = "foo"
         reserved_word.save
         reserved_word.errors.empty?.should be_true
@@ -115,5 +109,5 @@ require "../../spec_helper"
       end
     end
   end
-
+end
 {% end %}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -2,20 +2,9 @@ require "spec"
 
 module GraniteExample
   ADAPTERS = ["pg","mysql","sqlite"]
-  @@model_classes = [] of Granite::ORM::Base.class
-
-  extend self
-
-  def model_classes
-    @@model_classes
-  end
 end
 
 require "../src/granite_orm"
 require "./spec_models"
 
 Granite::ORM.settings.logger = ::Logger.new(nil)
-
-GraniteExample.model_classes.each do |model|
-  model.drop_and_create
-end


### PR DESCRIPTION
In current specs, it seems **adapter name** will be embedded in many places by macro in order to avoid class name conflict between three adapters.

This PR uses modules like `Pg`, `Mysql`, `Sqlite` to avoid the conflict, and keeps model and db schema simple by removing macro variables like xxx_constant, xxx_suffix, xxx_table, xxx_literal from spec codes.

##### master
```crystal
# model definitions
adapter_const_suffix = adapter.camelcase.id
adapter_suffix = "_#{adapter.id}".id
parent_table = "parent_#{adapter_literal}s".id

class Parent{{ adapter_const_suffix }} < Granite::ORM::Base
  table_name "{{ parent_table }}"
  has_many :student_{{ adapter_literal }}s

# specs
parent_constant = "Parent#{adapter.camelcase.id}".id
all = {{ parent_constant }}.all
```

##### PR
```crystal
# model definitions
module {{adapter.capitalize.id}}
  class Parent < Granite::ORM::Base
    table_name parents
    has_many :students

# specs
module {{adapter.capitalize.id}}
  all = Parent.all
```

Best regards,
