### PR TITLE
Fix `quote` about "table.column", and it now guarantees idempotency.

### DIFF
--- a/spec/adapter/mysql_spec.cr
+++ b/spec/adapter/mysql_spec.cr
@@ -1,1 +1,28 @@
 require "../spec_helper"
+
+private def adapter
+  Granite::Adapter::Mysql.new("mysql")
+end
+
+describe Granite::Adapter::Mysql do
+  describe "#quote" do
+    context "simple value" do
+      it "should return `foo`" do
+        adapter.quote("foo").should eq("`foo`")
+      end
+    end
+
+    context "dotted value" do
+      it "should return `foo`.`bar`" do
+        adapter.quote("foo.bar").should eq("`foo`.`bar`")
+      end
+    end
+
+    context "already quoted value" do
+      it "guarantees idempotency" do
+        adapter.quote("`foo`").should eq("`foo`")
+        adapter.quote("`foo`.`bar`").should eq("`foo`.`bar`")
+      end
+    end
+  end
+end

--- a/spec/adapter/pg_spec.cr
+++ b/spec/adapter/pg_spec.cr
@@ -1,1 +1,28 @@
 require "../spec_helper"
+
+private def adapter
+  Granite::Adapter::Pg.new("pg")
+end
+
+describe Granite::Adapter::Pg do
+  describe "#quote" do
+    context "simple value" do
+      it %(should return "foo") do
+        adapter.quote("foo").should eq(%("foo"))
+      end
+    end
+
+    context "dotted value" do
+      it %(should return "foo"."bar") do
+        adapter.quote("foo.bar").should eq(%("foo"."bar"))
+      end
+    end
+
+    context "already quoted value" do
+      it "guarantees idempotency" do
+        adapter.quote(%("foo")).should eq(%("foo"))
+        adapter.quote(%("foo"."bar")).should eq(%("foo"."bar"))
+      end
+    end
+  end
+end

--- a/spec/adapter/sqlite_spec.cr
+++ b/spec/adapter/sqlite_spec.cr
@@ -1,1 +1,28 @@
 require "../spec_helper"
+
+private def adapter
+  Granite::Adapter::Sqlite.new("sqlite")
+end
+
+describe Granite::Adapter::Sqlite do
+  describe "#quote" do
+    context "simple value" do
+      it %(should return "foo") do
+        adapter.quote("foo").should eq(%("foo"))
+      end
+    end
+
+    context "dotted value" do
+      it %(should return "foo"."bar") do
+        adapter.quote("foo.bar").should eq(%("foo"."bar"))
+      end
+    end
+
+    context "already quoted value" do
+      it "guarantees idempotency" do
+        adapter.quote(%("foo")).should eq(%("foo"))
+        adapter.quote(%("foo"."bar")).should eq(%("foo"."bar"))
+      end
+    end
+  end
+end

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -65,7 +65,7 @@ abstract class Granite::Adapter::Base
     # quotes table and column names
     def quote(name : String) : String
       char = QUOTING_CHAR
-      char + name.gsub(char, "#{char}#{char}") + char
+      char + name.delete(char).gsub(".", "#{char}.#{char}") + char
     end
   end
 


### PR DESCRIPTION
As @docelic said in #149, there is a bug about incorrect quoting.

```crystal
quote("foo.bar")  # => "foo.bar" (expected "foo"."bar")
```

This PR
- fixed to handle dotted input correctly
- added specs about this issue
- also now guarantees idempotency

For example, `Mysql` adapter works as follows.
```crystal
quote("foo")         # => "`foo`"
quote("foo.bar")     # => "`foo`.`bar`" (FIXED)
quote("`foo`")       # => "`foo`"       (NEW: idempotency)
quote("`foo`.`bar`") # => "`foo`.`bar`" (NEW: idempotency)
```

Best regards,