### PR TITLE
add record statuses about persistence: `new_record?`, `destroyed?`, `persisted?`

### DIFF
--- a/spec/granite_orm/querying/all_spec.cr
+++ b/spec/granite_orm/querying/all_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #all" do
     it "finds all the records" do
+      Parent.clear
       model_ids = (0...100).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)

--- a/spec/granite_orm/querying/count_spec.cr
+++ b/spec/granite_orm/querying/count_spec.cr
@@ -4,17 +4,18 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #count" do
     it "returns 0 if no result" do
+      Parent.clear
       count = Parent.count
       count.should eq 0
     end
 
     it "returns a number of the all records for the model" do
+      count = Parent.count
       2.times do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end
 
-      count = Parent.count
-      count.should eq 2
+      (Parent.count - count).should eq 2
     end
   end
 end

--- a/spec/granite_orm/querying/find_by_spec.cr
+++ b/spec/granite_orm/querying/find_by_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_by?, #find_by" do
     it "finds an object with a string field" do
+      Parent.clear
       name = "robinson"
 
       model = Parent.new
@@ -18,6 +19,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "finds an object with a symbol field" do
+      Parent.clear
       name = "robinson"
 
       model = Parent.new
@@ -32,6 +34,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "also works with reserved words" do
+      Parent.clear
       value = "robinson"
 
       model = ReservedWord.new
@@ -46,6 +49,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "returns nil or raises if no result" do
+      Parent.clear
       found = Parent.find_by?("name", "xxx")
       found.should be_nil
 

--- a/spec/granite_orm/querying/find_each_spec.cr
+++ b/spec/granite_orm/querying/find_each_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_each" do
     it "finds all the records" do
+      Parent.clear
       model_ids = (0...100).map do |i|
         Parent.new(name: "role_#{i}").tap {|r| r.save }
       end.map(&.id)
@@ -17,12 +18,14 @@ module {{adapter.capitalize.id}}
     end
 
     it "doesnt yield when no records are found" do
+      Parent.clear
       Parent.find_each do |model|
         fail "did yield"
       end
     end
 
     it "can start from an offset" do
+      Parent.clear
       created_models = (0...10).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
@@ -41,6 +44,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "doesnt obliterate a parameterized query" do
+      Parent.clear
       created_models = (0...10).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)

--- a/spec/granite_orm/querying/find_spec.cr
+++ b/spec/granite_orm/querying/find_spec.cr
@@ -16,6 +16,17 @@ module {{adapter.capitalize.id}}
       found.id.should eq model.id
     end
 
+    it "updates states of new_record and persisted" do
+      model = Parent.new
+      model.name = "Test Comment"
+      model.save
+      model_id = model.id
+
+      model = Parent.find(model_id)
+      model.new_record?.should be_false
+      model.persisted?.should be_true
+    end
+
     describe "with a custom primary key" do
       it "finds the object" do
         school = School.new

--- a/spec/granite_orm/querying/first_spec.cr
+++ b/spec/granite_orm/querying/first_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #first?, #first" do
     it "finds the first object" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
@@ -22,6 +23,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "supports a SQL clause" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
@@ -40,6 +42,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "returns nil or raises if no result" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save

--- a/spec/granite_orm/transactions/destroy_spec.cr
+++ b/spec/granite_orm/transactions/destroy_spec.cr
@@ -14,6 +14,21 @@ module {{adapter.capitalize.id}}
       found.should be_nil
     end
 
+    it "updates states of destroyed and persisted" do
+      parent = Parent.new
+      parent.destroyed?.should be_false
+      parent.persisted?.should be_false
+
+      parent.name = "Test Parent"
+      parent.save
+      parent.destroyed?.should be_false
+      parent.persisted?.should be_true
+
+      parent.destroy
+      parent.destroyed?.should be_true
+      parent.persisted?.should be_false
+    end
+
     describe "with a custom primary key" do
       it "destroys an object" do
         school = School.new

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -18,6 +18,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "updates an existing object" do
+      Parent.clear
       parent = Parent.new
       parent.name = "Test Parent"
       parent.save

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -42,6 +42,17 @@ module {{adapter.capitalize.id}}
       parent.name.should eq "Test Parent"
     end
 
+    it "does not update when the conflicted primary key is given to the new record" do
+      parent1 = Parent.new
+      parent1.name = "Test Parent"
+      parent1.save.should be_true
+
+      parent2 = Parent.new
+      parent2.id = parent1.id
+      parent2.name = "Test Parent2"
+      parent2.save.should be_false
+    end
+
     describe "with a custom primary key" do
       it "creates a new object" do
         school = School.new
@@ -66,6 +77,17 @@ module {{adapter.capitalize.id}}
         found_school = School.find primary_key
         found_school.custom_id.should eq primary_key
         found_school.name.should eq new_name
+      end
+
+      it "updates states of new_record and persisted" do
+        parent = Parent.new
+        parent.new_record?.should be_true
+        parent.persisted?.should be_false
+
+        parent.name = "Test Parent"
+        parent.save
+        parent.new_record?.should be_false
+        parent.persisted?.should be_true
       end
     end
 

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -272,19 +272,5 @@ end
     Empty.drop_and_create
     ReservedWord.drop_and_create
     Callback.drop_and_create
-
-    Spec.before_each do
-      Parent.clear
-      Teacher.clear
-      Student.clear
-      Klass.clear
-      Enrollment.clear
-      School.clear
-      Nation::County.clear
-      Review.clear
-      Empty.clear
-      ReservedWord.clear
-      Callback.clear
-    end
   end
 {% end %}

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -10,18 +10,24 @@ module Granite::ORM::Querying
       # Create the from_sql method
       def self.from_sql(result)
         model = \{{@type.name.id}}.new
+        model.set_attributes(result)
+        model
+      end
 
-        model.\{{primary_name}} = result.read(\{{primary_type}})
+      def set_attributes(result : DB::ResultSet)
+        # Loading from DB means existing records.
+        @new_record = false
+        self.\{{primary_name}} = result.read(\{{primary_type}})
 
         \{% for name, type in FIELDS %}
-          model.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
+          self.\{{name.id}} = result.read(Union(\{{type.id}} | Nil))
         \{% end %}
 
         \{% if SETTINGS[:timestamps] %}
-          model.created_at = result.read(Union(Time | Nil))
-          model.updated_at = result.read(Union(Time | Nil))
+          self.created_at = result.read(Union(Time | Nil))
+          self.updated_at = result.read(Union(Time | Nil))
         \{% end %}
-        return model
+        return self
       end
     end
   end


### PR DESCRIPTION
This PR adds following three statuses to a record.
- `new_record?`, `destroyed?`, `persisted?`

| code         | new_record?           | destroyed?            | persisted?            |
|--------------|-----------------------|-----------------------|-----------------------|
| User.new     | :white_check_mark:    | :white_large_square: | :white_large_square:    |
| user.save    | :white_large_square: | :white_large_square: | :white_check_mark:    |
| user.destroy | :white_large_square: | :white_check_mark:    | :white_large_square: |
| User.find    | :white_large_square: | :white_large_square: | :white_check_mark:    |

In addition, now we can put any value for the primary key if we want. 
This solves `INSERT` problem in #143 and will also help introduce natural keys.

```crystal
user = User.new(name: "maiha")
user.id = 5
user.save
```

| IMPLEMENT | SQL                                                            |
|-----------|----------------------------------------------------------------|
| master    | UPDATE `users` SET `name`=? WHERE `id`=?: ["maiha", 5]         |
| PR        | INSERT INTO `users` (`name`, `id`) VALUES (?, ?): ["maiha", 5] |
| Rails     | INSERT INTO `users` (`id`, `name`) VALUES (5, 'maiha')         |

These behaviors are same as Rails!

Best regards,