### PR TITLE
add spec for callbacks

### DIFF
--- a/spec/granite_orm/callbacks/callbacks_spec.cr
+++ b/spec/granite_orm/callbacks/callbacks_spec.cr
@@ -1,0 +1,61 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} (callback feature)" do
+    describe "#save (new record)" do
+      it "runs before_save, before_create, after_create, after_save" do
+        callback = Callback.new(name: "foo")
+        callback.save
+
+        callback.history.to_s.strip.should eq <<-EOF
+          before_save
+          before_create
+          after_create
+          after_save
+          EOF
+      end
+    end
+
+    describe "#save" do
+      it "runs before_save, before_update, after_update, after_save" do
+        Callback.new(name: "foo").save
+        callback = Callback.first
+        callback.save
+
+        callback.history.to_s.strip.should eq <<-EOF
+          before_save
+          before_update
+          after_update
+          after_save
+          EOF
+      end
+    end
+
+    describe "#destroy" do
+      it "runs before_destroy, after_destroy" do
+        Callback.new(name: "foo").save
+        callback = Callback.first
+        callback.destroy
+
+        callback.history.to_s.strip.should eq <<-EOF
+          before_destroy
+          after_destroy
+          EOF
+      end
+    end
+
+    describe "an exception thrown in a hook" do
+      it "should not get swallowed" do
+        callback = Callback.new(name: "foo")
+        # close IO in order to raise IO::Error in callback blocks
+        callback.history.close
+
+        expect_raises(IO::Error, "Closed stream")  do
+          callback.save
+        end
+      end
+    end
+  end
+end
+{% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -235,6 +235,32 @@ end
       end
     end
 
+    class Callback < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name callbacks
+      primary id : Int64
+      field name : String
+
+      property history : IO::Memory = IO::Memory.new
+
+      {% for name in Granite::ORM::Callbacks::CALLBACK_NAMES %}
+        {{name.id}} _{{name.id}}
+        private def _{{name.id}}
+          history << "{{name.id}}\n"
+        end
+      {% end %}
+
+      def self.drop_and_create
+        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
+        exec <<-SQL
+          CREATE TABLE #{ quoted_table_name } (
+            id {{ primary_key_sql }},
+            name VARCHAR(100) NOT NULL
+          )
+        SQL
+      end
+    end
+
     Parent.drop_and_create
     Teacher.drop_and_create
     Student.drop_and_create
@@ -245,6 +271,7 @@ end
     Review.drop_and_create
     Empty.drop_and_create
     ReservedWord.drop_and_create
+    Callback.drop_and_create
 
     Spec.before_each do
       Parent.clear
@@ -257,6 +284,7 @@ end
       Review.clear
       Empty.clear
       ReservedWord.clear
+      Callback.clear
     end
   end
 {% end %}


### PR DESCRIPTION
https://github.com/amberframework/granite-orm/pull/153#discussion_r170689455
> an exception thrown in a hook will get swallowed

This PR explicitly specifies why `DB::Error` is rescued in `#save`. After this PR, we can detect #153 is well regressed. 😄 

In addition, this also ensures the callbacks are fired and its order.
Best regard,