### PR TITLE
spec: don't clear database automatically

### DIFF
--- a/spec/granite_orm/querying/all_spec.cr
+++ b/spec/granite_orm/querying/all_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #all" do
     it "finds all the records" do
+      Parent.clear
       model_ids = (0...100).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)

--- a/spec/granite_orm/querying/count_spec.cr
+++ b/spec/granite_orm/querying/count_spec.cr
@@ -4,17 +4,18 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #count" do
     it "returns 0 if no result" do
+      Parent.clear
       count = Parent.count
       count.should eq 0
     end
 
     it "returns a number of the all records for the model" do
+      count = Parent.count
       2.times do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end
 
-      count = Parent.count
-      count.should eq 2
+      (Parent.count - count).should eq 2
     end
   end
 end

--- a/spec/granite_orm/querying/find_by_spec.cr
+++ b/spec/granite_orm/querying/find_by_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_by?, #find_by" do
     it "finds an object with a string field" do
+      Parent.clear
       name = "robinson"
 
       model = Parent.new
@@ -18,6 +19,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "finds an object with a symbol field" do
+      Parent.clear
       name = "robinson"
 
       model = Parent.new
@@ -32,6 +34,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "also works with reserved words" do
+      Parent.clear
       value = "robinson"
 
       model = ReservedWord.new
@@ -46,6 +49,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "returns nil or raises if no result" do
+      Parent.clear
       found = Parent.find_by?("name", "xxx")
       found.should be_nil
 

--- a/spec/granite_orm/querying/find_each_spec.cr
+++ b/spec/granite_orm/querying/find_each_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #find_each" do
     it "finds all the records" do
+      Parent.clear
       model_ids = (0...100).map do |i|
         Parent.new(name: "role_#{i}").tap {|r| r.save }
       end.map(&.id)
@@ -17,12 +18,14 @@ module {{adapter.capitalize.id}}
     end
 
     it "doesnt yield when no records are found" do
+      Parent.clear
       Parent.find_each do |model|
         fail "did yield"
       end
     end
 
     it "can start from an offset" do
+      Parent.clear
       created_models = (0...10).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)
@@ -41,6 +44,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "doesnt obliterate a parameterized query" do
+      Parent.clear
       created_models = (0...10).map do |i|
         Parent.new(name: "model_#{i}").tap(&.save)
       end.map(&.id)

--- a/spec/granite_orm/querying/first_spec.cr
+++ b/spec/granite_orm/querying/first_spec.cr
@@ -4,6 +4,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} #first?, #first" do
     it "finds the first object" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
@@ -22,6 +23,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "supports a SQL clause" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save
@@ -40,6 +42,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "returns nil or raises if no result" do
+      Parent.clear
       first = Parent.new.tap do |model|
         model.name = "Test 1"
         model.save

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -18,6 +18,7 @@ module {{adapter.capitalize.id}}
     end
 
     it "updates an existing object" do
+      Parent.clear
       parent = Parent.new
       parent.name = "Test Parent"
       parent.save

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -272,19 +272,5 @@ end
     Empty.drop_and_create
     ReservedWord.drop_and_create
     Callback.drop_and_create
-
-    Spec.before_each do
-      Parent.clear
-      Teacher.clear
-      Student.clear
-      Klass.clear
-      Enrollment.clear
-      School.clear
-      Nation::County.clear
-      Review.clear
-      Empty.clear
-      ReservedWord.clear
-      Callback.clear
-    end
   end
 {% end %}


### PR DESCRIPTION
In current specs, every time we run one test case, we initialize 33 tables with 3 adapters in total. 

```crystal
# pseudo code
Spec.before_each do
  adapters.each do |adapter| # 3 times
    adapter::table1.clear    # 11 tables in total
    ...
```

This is **expensive** to run and is **unnecessary** work for most test cases. Therefore, execution of all tests is very slow and this cost will continue to increase each time additional functionality is added.

In this PR, I propose a policy to delete tables **manually** rather than **automatically**. When writing a test, we do not assume that the table is empty, we need to manually run the table as needed.

#### Benchmark

In my environment.

##### master

- `8m13s` (with 6118 DB operations)

##### PR

- `43s` (with 1012 DB operations)

FYI: This is a commits dependency for natural-key in my fork.
1. #154 add spec for callbacks (merged) 🎉 
2. #165 spec: don't clear database automatically (This PR)
3. #153 add record statuses about persistence
4. #143 `primary auto: false` works as a natural key

Best regards,