### PR TITLE
Supporting natural keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ end
 
 This will override the default primary key of `id : Int64`.
 
+### Natural Key
+
+For natural keys, you can set `auto: false` option to disable auto increment insert.
+
+```crystal
+class Site < Granite::ORM::Base
+  adapter mysql
+  primary code : String, auto: false
+  field name : String
+end
+```
+
 ### SQL
 
 To clear all the rows in the database:

--- a/spec/granite_orm/fields/primary_key_spec.cr
+++ b/spec/granite_orm/fields/primary_key_spec.cr
@@ -1,0 +1,24 @@
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} .new" do
+    it "works when the primary is defined as `auto: true`" do
+      Parent.new
+    end
+
+    it "works when the primary is defined as `auto: false`" do
+      Kvs.new
+    end
+  end
+
+  describe "{{ adapter.id }} .new(primary_key: value)" do
+    it "ignores the value in default" do
+      Parent.new(id: 1).id?.should eq(nil)
+    end
+
+    it "sets the value when the primary is defined as `auto: false`" do
+      Kvs.new(k: "foo").k?.should eq("foo")
+      Kvs.new(k: "foo", v: "v").k?.should eq("foo")
+    end
+  end
+end
+{% end %}

--- a/spec/granite_orm/transactions/save_natural_key_spec.cr
+++ b/spec/granite_orm/transactions/save_natural_key_spec.cr
@@ -1,0 +1,81 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "(Natural Key){{ adapter.id }} #save" do
+    it "fails when a primary key is not set" do
+      kv = Kvs.new
+      kv.save.should be_false
+      kv.errors.first.message.should eq "Primary key('k') cannot be null"
+    end
+
+    it "creates a new object when a primary key is given" do
+      kv = Kvs.new
+      kv.k = "foo"
+      kv.save.should be_true
+
+      kv = Kvs.find("foo").not_nil!
+      kv.k.should eq("foo")
+    end
+
+    it "updates an existing object" do
+      kv = Kvs.new
+      kv.k = "foo"
+      kv.v = "1"
+      kv.save.should be_true
+
+      kv.v = "2"
+      kv.save.should be_true
+      kv.k.should eq("foo")
+      kv.v.should eq("2")
+    end
+  end
+
+  describe "(Natural Key){{ adapter.id }} usecases" do
+    it "CRUD" do
+      Kvs.clear
+
+      ## Create
+      port = Kvs.new(k: "mysql_port", v: "3306")
+      port.new_record?.should be_true
+      port.save.should be_true
+      port.v.should eq("3306")
+      Kvs.count.should eq(1)
+
+      ## Read
+      port = Kvs.find("mysql_port")
+      port.v.should eq("3306")
+      port.new_record?.should be_false
+
+      ## Update
+      port.v = "3307"
+      port.new_record?.should be_false
+      port.save.should be_true
+      port.v.should eq("3307")
+      Kvs.count.should eq(1)
+
+      ## Delete
+      port.destroy.should be_true
+      Kvs.count.should eq(0)
+    end
+
+    it "creates a new record twice" do
+      Kvs.clear
+
+      # create a new record
+      port = Kvs.new(k: "mysql_port", v: "3306")
+      port.new_record?.should be_true
+      port.save.should be_true
+      port.v.should eq("3306")
+      Kvs.count.should eq(1)
+
+      # create a new record again
+      port = Kvs.new(k: "mysql_port", v: "3306")
+      port.new_record?.should be_true
+      port.save.should be_true
+      port.v.should eq("3306")
+      Kvs.count.should eq(2)
+    end
+  end
+end
+{% end %}

--- a/spec/spec_models.cr
+++ b/spec/spec_models.cr
@@ -261,6 +261,23 @@ end
       end
     end
 
+    class Kvs < Granite::ORM::Base
+      adapter {{ adapter_literal }}
+      table_name kvss
+      primary k : String, auto: false
+      field v : String
+
+      def self.drop_and_create
+        exec "DROP TABLE IF EXISTS #{ quoted_table_name }"
+        exec <<-SQL
+          CREATE TABLE #{ quoted_table_name } (
+            k VARCHAR(255),
+            v VARCHAR(255)
+          )
+        SQL
+      end
+    end
+
     Parent.drop_and_create
     Teacher.drop_and_create
     Student.drop_and_create
@@ -272,5 +289,6 @@ end
     Empty.drop_and_create
     ReservedWord.drop_and_create
     Callback.drop_and_create
+    Kvs.drop_and_create
   end
 {% end %}

--- a/src/adapter/base.cr
+++ b/src/adapter/base.cr
@@ -47,7 +47,7 @@ abstract class Granite::Adapter::Base
   # abstract def select_one(table_name, fields, field, id, &block)
 
   # This will insert a row in the database and return the id generated.
-  abstract def insert(table_name, fields, params) : Int64
+  abstract def insert(table_name, fields, params, lastval) : Int64
 
   # This will update a row in the database.
   abstract def update(table_name, primary_name, fields, params)

--- a/src/adapter/mysql.cr
+++ b/src/adapter/mysql.cr
@@ -55,7 +55,7 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
     end
   end
 
-  def insert(table_name, fields, params)
+  def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")
@@ -68,7 +68,11 @@ class Granite::Adapter::Mysql < Granite::Adapter::Base
 
     open do |db|
       db.exec statement, params
-      return db.scalar(last_val()).as(Int64)
+      if lastval
+        return db.scalar(last_val()).as(Int64)
+      else
+        return -1_i64
+      end
     end
   end
 

--- a/src/adapter/pg.cr
+++ b/src/adapter/pg.cr
@@ -55,7 +55,7 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
     end
   end
 
-  def insert(table_name, fields, params)
+  def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")
@@ -68,7 +68,11 @@ class Granite::Adapter::Pg < Granite::Adapter::Base
 
     open do |db|
       db.exec statement, params
-      return db.scalar(last_val()).as(Int64)
+      if lastval
+        return db.scalar(last_val()).as(Int64)
+      else
+        return -1_i64
+      end
     end
   end
 

--- a/src/adapter/sqlite.cr
+++ b/src/adapter/sqlite.cr
@@ -53,7 +53,7 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
     end
   end
 
-  def insert(table_name, fields, params)
+  def insert(table_name, fields, params, lastval)
     statement = String.build do |stmt|
       stmt << "INSERT INTO #{quote(table_name)} ("
       stmt << fields.map { |name| "#{quote(name)}" }.join(", ")
@@ -66,7 +66,11 @@ class Granite::Adapter::Sqlite < Granite::Adapter::Base
 
     open do |db|
       db.exec statement, params
-      return db.scalar(last_val()).as(Int64)
+      if lastval
+        return db.scalar(last_val()).as(Int64)
+      else
+        return -1_i64
+      end
     end
   end
 

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -127,6 +127,11 @@ module Granite::ORM::Fields
     private def cast_to_field(name, value : Type)
       {% unless FIELDS.empty? %}
         case name.to_s
+          when "{{PRIMARY[:name]}}"
+            {% if !PRIMARY[:auto] %}
+              @{{PRIMARY[:name]}} = value.as({{PRIMARY[:type]}})
+            {% end %}
+          
           {% for _name, type in FIELDS %}
           when "{{_name.id}}"
             return @{{_name.id}} = nil if value.nil?

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -2,7 +2,7 @@ module Granite::ORM::Table
   macro included
     macro inherited
       SETTINGS = {} of Nil => Nil
-      PRIMARY = {name: id, type: Int64}
+      PRIMARY = {name: id, type: Int64, auto: true}
     end
   end
 
@@ -27,14 +27,23 @@ module Granite::ORM::Table
     {% PRIMARY[:type] = decl.type %}
   end
 
+  # specify the primary key column and type and auto_increment
+  macro primary(decl, auto)
+    {% PRIMARY[:name] = decl.var %}
+    {% PRIMARY[:type] = decl.type %}
+    {% PRIMARY[:auto] = auto %}
+  end
+
   macro __process_table
     {% name_space = @type.name.gsub(/::/, "_").underscore.id %}
     {% table_name = SETTINGS[:table_name] || name_space + "s" %}
     {% primary_name = PRIMARY[:name] %}
     {% primary_type = PRIMARY[:type] %}
+    {% primary_auto = PRIMARY[:auto] %}
 
     @@table_name = "{{table_name}}"
     @@primary_name = "{{primary_name}}"
+    @@primary_auto = "{{primary_auto}}"
 
     property? {{primary_name}} : Union({{primary_type.id}} | Nil)
 
@@ -49,6 +58,10 @@ module Granite::ORM::Table
 
     def self.primary_name
       @@primary_name
+    end
+
+    def self.primary_auto
+      @@primary_auto
     end
 
     def self.quoted_table_name


### PR DESCRIPTION
This PR enhances `Model.primary` to accept `auto` option that works as a natural key if false.

### Example (use RDB as KVS)

```
mysql> DESCRIBE kvss;
+-------+--------------+------+-----+---------+-------+
| Field | Type         | Null | Key | Default | Extra |
+-------+--------------+------+-----+---------+-------+
| k     | varchar(255) | NO   | PRI | NULL    |       |
| v     | varchar(255) | YES  |     | NULL    |       |
+-------+--------------+------+-----+---------+-------+
```

```crystal
class Kvs < Granite::ORM::Base
  adapter mysql
  primary k : String
  field   v : String
end
```

First, if you use a primary key other than Int as described above, it will give a compile error with following suggestion.


```crystal
Failed to define Kvs#save: Primary key must be Int(32|64), or set `auto: false` for natural keys.

  primary k : String, auto: false
```

After adding `auto: false` that disables **auto number** feature, we can play with nartural keys.

```crystal
class Kvs < Granite::ORM::Base
  adapter mysql
  primary k : String, auto: false
  field   v : String
end
```

```crystal
## Create
port = Kvs.new(k: "mysql_port", v: "3306")
port.new_record? # => true
port.save        # => true
# INSERT INTO `kvs` (`v`, `k`) VALUES (?, ?): ["3306", "mysql_port"]
Kvs.count        # => 1

## Read
port = Kvs.find("mysql_port")
port.new_record? # => false
port.v           # => "3306"

## Update
port.v = "3307"
port.new_record? # => false
port.save        # => true
# UPDATE `kvs` SET `v`=? WHERE `k`=?: ["3307", "mysql_port"]

## Delete
port.destroy     # => true
Kvs.count        # => 0
```

Best regards,