### PR TITLE
Fix .create class method

### DIFF
--- a/spec/granite_orm/transactions/create_spec.cr
+++ b/spec/granite_orm/transactions/create_spec.cr
@@ -1,0 +1,42 @@
+require "../../spec_helper"
+
+{% for adapter in GraniteExample::ADAPTERS %}
+module {{adapter.capitalize.id}}
+  describe "{{ adapter.id }} .create" do
+    it "creates a new object" do
+      parent = Parent.create(name: "Test Parent")
+      parent.id.should_not be_nil
+      parent.name.should eq("Test Parent")
+    end
+
+    it "does not create an invalid object" do
+      parent = Parent.create(name: "")
+      parent.id?.should be_nil
+    end
+
+    describe "with a custom primary key" do
+      it "creates a new object" do
+        school = School.create(name: "Test School")
+        school.custom_id.should_not be_nil
+        school.name.should eq("Test School")
+      end
+    end
+
+    describe "with a modulized model" do
+      it "creates a new object" do
+        county = Nation::County.create(name: "Test School")
+        county.id.should_not be_nil
+        county.name.should eq("Test School")
+      end
+    end
+
+    describe "using a reserved word as a column name" do
+      it "creates a new object" do
+        reserved_word = ReservedWord.create(all: "foo")
+        reserved_word.errors.empty?.should be_true
+        reserved_word.all.should eq("foo")
+      end
+    end
+  end
+end
+{% end %}

--- a/src/granite_orm/base.cr
+++ b/src/granite_orm/base.cr
@@ -18,6 +18,7 @@ class Granite::ORM::Base
   include Validators
 
   extend Querying
+  extend Transactions::ClassMethods
 
   macro inherited
     macro finished

--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -60,14 +60,16 @@ module Granite::ORM::Transactions
     end
   end
 
-  def create(**args)
-    create(args.to_h)
-  end
+  module ClassMethods 
+    def create(**args)
+      create(args.to_h)
+    end
 
-  def create(args : Hash(Symbol | String, DB::Any))
-    instance = new
-    instance.set_attributes(args)
-    instance.save
-    instance
+    def create(args : Hash(Symbol | String, DB::Any))
+      instance = new
+      instance.set_attributes(args)
+      instance.save
+      instance
+    end
   end
 end


### PR DESCRIPTION
From commit history, this looks like regression after extracting some modules.

Example usage:
```
parent = Parent.create(name: "Test Parent")
```
or (more useful example)
```
params = { name: "Test Parent" }.to_h
parent = Parent.create(params)
```
instead of 
```
parent = Parent.new
parent.name = "Test Parent"
parent.save
```