### PR TITLE
refactor: Unify pk and content and timestamps into `FIELDS`

### DIFF
--- a/src/granite_orm/transactions.cr
+++ b/src/granite_orm/transactions.cr
@@ -20,10 +20,11 @@ module Granite::ORM::Transactions
         if (value = @{{primary_name}}) && !new_record?
           __run_before_update
           @updated_at = now
-          params_and_pk = params
-          params_and_pk << value
+          fields = self.class.content_fields
+          params = content_values + [value]
+
           begin
-            @@adapter.update @@table_name, @@primary_name, self.class.fields, params_and_pk
+            @@adapter.update @@table_name, @@primary_name, fields, params
           rescue err
             raise DB::Error.new(err.message)
           end
@@ -31,8 +32,8 @@ module Granite::ORM::Transactions
         else
           __run_before_create
           @created_at = @updated_at = now
-          params = params()
-          fields = self.class.fields
+          fields = self.class.content_fields.dup
+          params = content_values
           if value = @{{primary_name}}
             fields << "{{primary_name}}"
             params << value


### PR DESCRIPTION
In master, when we want to iterate all fields, we have to process three kinds of fields **pk**, **content columns** and **timestamps** as following code. I feel this is a boring work and the code looks difficult.

```crystal
def to_xxx
  # for PK
  {{ PRIMARY[:name] }}

  # for Content
  {% for name, type in FIELDS %}
     ...

  # for timestamps
  {% if SETTINGS[:timestamps] %}
```

This PR merges them into one FIELDS, and the `primary` and `timestamp` now becomes just wrapper macros to the `field`. Thus, we can simply iterate `FIELDS` to scan all fields.

```crystal
def to_xxx
  {% for name, type in FIELDS %}
     ...
```

##### related refactor (Granite::ORM::Base)
- added `CONTENT_FIELDS` that removes **PK** from `FIELDS`
- added `Base.fields` to provide cached field names.
- added `Base.content_fields` to provide cached content field names.
- renamed `Base#params` to `Base#content_values` for clarity


Best regards,