### PR TITLE
changes syntax for helper methods from ? to !

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,34 +138,34 @@ end
 #### Find First
 
 ```crystal
-post = Post.first?
+post = Post.first
 if post
   puts post.name
 end
 
-post = Post.first # raises when no records exist
+post = Post.first! # raises when no records exist
 ```
 
 #### Find
 
 ```crystal
-post = Post.find? 1
+post = Post.find 1
 if post
   puts post.name
 end
 
-post = Post.find 1 # raises when no records found
+post = Post.find! 1 # raises when no records found
 ```
 
 #### Find By
 
 ```crystal
-post = Post.find_by? :slug, "example_slug"
+post = Post.find_by :slug, "example_slug"
 if post
   puts post.name
 end
 
-post = Post.find_by :slug, "foo" # raises when no records found
+post = Post.find_by! :slug, "foo" # raises when no records found
 ```
 
 #### Insert

--- a/spec/granite_orm/callbacks/callbacks_spec.cr
+++ b/spec/granite_orm/callbacks/callbacks_spec.cr
@@ -20,7 +20,7 @@ module {{adapter.capitalize.id}}
     describe "#save" do
       it "runs before_save, before_update, after_update, after_save" do
         Callback.new(name: "foo").save
-        callback = Callback.first
+        callback = Callback.first!
         callback.save
 
         callback.history.to_s.strip.should eq <<-EOF
@@ -35,7 +35,7 @@ module {{adapter.capitalize.id}}
     describe "#destroy" do
       it "runs before_destroy, after_destroy" do
         Callback.new(name: "foo").save
-        callback = Callback.first
+        callback = Callback.first!
         callback.destroy
 
         callback.history.to_s.strip.should eq <<-EOF

--- a/spec/granite_orm/fields/primary_key_spec.cr
+++ b/spec/granite_orm/fields/primary_key_spec.cr
@@ -12,12 +12,12 @@ module {{adapter.capitalize.id}}
 
   describe "{{ adapter.id }} .new(primary_key: value)" do
     it "ignores the value in default" do
-      Parent.new(id: 1).id?.should eq(nil)
+      Parent.new(id: 1).id.should eq(nil)
     end
 
     it "sets the value when the primary is defined as `auto: false`" do
-      Kvs.new(k: "foo").k?.should eq("foo")
-      Kvs.new(k: "foo", v: "v").k?.should eq("foo")
+      Kvs.new(k: "foo").k.should eq("foo")
+      Kvs.new(k: "foo", v: "v").k.should eq("foo")
     end
   end
 end

--- a/spec/granite_orm/fields/timestamps_spec.cr
+++ b/spec/granite_orm/fields/timestamps_spec.cr
@@ -5,7 +5,7 @@ require "../../spec_helper"
 module {{adapter.capitalize.id}}
   {%
     avoid_macro_bug = 1 # https://github.com/crystal-lang/crystal/issues/5724
-    
+
     # TODO mysql timestamp support should work better
     if adapter == "pg"
       time_kind_on_read = "Time::Kind::Utc".id
@@ -17,10 +17,10 @@ module {{adapter.capitalize.id}}
   describe "{{ adapter.id }} timestamps" do
     it "consistently uses UTC for created_at" do
       parent = Parent.new(name: "parent").tap(&.save)
-      found_parent = Parent.find(parent.id)
+      found_parent = Parent.find!(parent.id)
 
-      original_timestamp = parent.created_at
-      read_timestamp = found_parent.created_at
+      original_timestamp = parent.created_at!
+      read_timestamp = found_parent.created_at!
 
       original_timestamp.kind.should eq Time::Kind::Utc
       read_timestamp.kind.should eq {{ time_kind_on_read }}
@@ -28,10 +28,10 @@ module {{adapter.capitalize.id}}
 
     it "consistently uses UTC for updated_at" do
       parent = Parent.new(name: "parent").tap(&.save)
-      found_parent = Parent.find(parent.id)
+      found_parent = Parent.find!(parent.id)
 
-      original_timestamp = parent.updated_at
-      read_timestamp = found_parent.updated_at
+      original_timestamp = parent.updated_at!
+      read_timestamp = found_parent.updated_at!
 
       original_timestamp.kind.should eq Time::Kind::Utc
       read_timestamp.kind.should eq {{ time_kind_on_read }}
@@ -39,20 +39,20 @@ module {{adapter.capitalize.id}}
 
     it "truncates the subsecond parts of created_at" do
       parent = Parent.new(name: "parent").tap(&.save)
-      found_parent = Parent.find(parent.id)
+      found_parent = Parent.find!(parent.id)
 
-      original_timestamp = parent.created_at
-      read_timestamp = found_parent.created_at
+      original_timestamp = parent.created_at!
+      read_timestamp = found_parent.created_at!
 
       original_timestamp.epoch.should eq read_timestamp.epoch
     end
 
     it "truncates the subsecond parts of updated_at" do
       parent = Parent.new(name: "parent").tap(&.save)
-      found_parent = Parent.find(parent.id)
+      found_parent = Parent.find!(parent.id)
 
-      original_timestamp = parent.updated_at
-      read_timestamp = found_parent.updated_at
+      original_timestamp = parent.updated_at!
+      read_timestamp = found_parent.updated_at!
 
       original_timestamp.epoch.should eq read_timestamp.epoch
     end

--- a/spec/granite_orm/querying/find_by_spec.cr
+++ b/spec/granite_orm/querying/find_by_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
 module {{adapter.capitalize.id}}
-  describe "{{ adapter.id }} #find_by?, #find_by" do
+  describe "{{ adapter.id }} #find_by, #find_by!" do
     it "finds an object with a string field" do
       Parent.clear
       name = "robinson"
@@ -11,10 +11,10 @@ module {{adapter.capitalize.id}}
       model.name = name
       model.save
 
-      found = Parent.find_by?("name", name)
+      found = Parent.find_by("name", name)
       found.not_nil!.id.should eq model.id
 
-      found = Parent.find_by("name", name)
+      found = Parent.find_by!("name", name)
       found.should be_a(Parent)
     end
 
@@ -26,10 +26,10 @@ module {{adapter.capitalize.id}}
       model.name = name
       model.save
 
-      found = Parent.find_by?(:name, name)
+      found = Parent.find_by(:name, name)
       found.not_nil!.id.should eq model.id
 
-      found = Parent.find_by(:name, name)
+      found = Parent.find_by!(:name, name)
       found.id.should eq model.id
     end
 
@@ -41,20 +41,20 @@ module {{adapter.capitalize.id}}
       model.all = value
       model.save
 
-      found = ReservedWord.find_by?("all", value)
+      found = ReservedWord.find_by("all", value)
       found.not_nil!.id.should eq model.id
 
-      found = ReservedWord.find_by(:all, value)
+      found = ReservedWord.find_by!(:all, value)
       found.id.should eq model.id
     end
 
     it "returns nil or raises if no result" do
       Parent.clear
-      found = Parent.find_by?("name", "xxx")
+      found = Parent.find_by("name", "xxx")
       found.should be_nil
 
       expect_raises(Granite::ORM::Querying::NotFound, /Couldn't find .*Parent.* with name=xxx/) do
-        Parent.find_by("name", "xxx")
+        Parent.find_by!("name", "xxx")
       end
     end
   end

--- a/spec/granite_orm/querying/find_spec.cr
+++ b/spec/granite_orm/querying/find_spec.cr
@@ -2,17 +2,17 @@ require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
 module {{adapter.capitalize.id}}
-  describe "{{ adapter.id }} #find?, #find" do
+  describe "{{ adapter.id }} #find, #find!" do
     it "finds an object by id" do
       model = Parent.new
       model.name = "Test Comment"
       model.save
 
-      found = Parent.find? model.id
+      found = Parent.find model.id
       found.should_not be_nil
       found.not_nil!.id.should eq model.id
 
-      found = Parent.find model.id
+      found = Parent.find! model.id
       found.id.should eq model.id
     end
 
@@ -22,7 +22,7 @@ module {{adapter.capitalize.id}}
       model.save
       model_id = model.id
 
-      model = Parent.find(model_id)
+      model = Parent.find!(model_id)
       model.new_record?.should be_false
       model.persisted?.should be_true
     end
@@ -34,10 +34,10 @@ module {{adapter.capitalize.id}}
         school.save
         primary_key = school.custom_id
 
-        found_school = School.find? primary_key
+        found_school = School.find primary_key
         found_school.should_not be_nil
 
-        found_school = School.find primary_key
+        found_school = School.find! primary_key
         found_school.should be_a(School)
       end
     end
@@ -49,20 +49,20 @@ module {{adapter.capitalize.id}}
         county.save
         primary_key = county.id
 
-        found_county = Nation::County.find? primary_key
+        found_county = Nation::County.find primary_key
         found_county.should_not be_nil
 
-        found_county = Nation::County.find primary_key
+        found_county = Nation::County.find! primary_key
         found_county.should be_a(Nation::County)
       end
     end
 
     it "returns nil or raises if no result" do
-      found = Parent.find? 0
+      found = Parent.find 0
       found.should be_nil
-      
+
       expect_raises(Granite::ORM::Querying::NotFound, /Couldn't find .*Parent.* with id=0/) do
-        Parent.find 0
+        Parent.find! 0
       end
     end
   end

--- a/spec/granite_orm/querying/first_spec.cr
+++ b/spec/granite_orm/querying/first_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 {% for adapter in GraniteExample::ADAPTERS %}
 module {{adapter.capitalize.id}}
-  describe "{{ adapter.id }} #first?, #first" do
+  describe "{{ adapter.id }} #first, #first!" do
     it "finds the first object" do
       Parent.clear
       first = Parent.new.tap do |model|
@@ -15,10 +15,10 @@ module {{adapter.capitalize.id}}
         model.save
       end
 
-      found = Parent.first?
+      found = Parent.first
       found.not_nil!.id.should eq first.id
 
-      found = Parent.first
+      found = Parent.first!
       found.id.should eq first.id
     end
 
@@ -34,10 +34,10 @@ module {{adapter.capitalize.id}}
         model.save
       end
 
-      found = Parent.first?("ORDER BY id DESC")
+      found = Parent.first("ORDER BY id DESC")
       found.not_nil!.id.should eq second.id
 
-      found = Parent.first("ORDER BY id DESC")
+      found = Parent.first!("ORDER BY id DESC")
       found.id.should eq second.id
     end
 
@@ -48,11 +48,11 @@ module {{adapter.capitalize.id}}
         model.save
       end
 
-      found = Parent.first?("WHERE name = 'Test 2'")
+      found = Parent.first("WHERE name = 'Test 2'")
       found.should be nil
 
       expect_raises(Granite::ORM::Querying::NotFound, /Couldn't find .*Parent.* with first\(WHERE name = 'Test 2'\)/) do
-        Parent.first("WHERE name = 'Test 2'")
+        Parent.first!("WHERE name = 'Test 2'")
       end
     end
   end

--- a/spec/granite_orm/transactions/create_spec.cr
+++ b/spec/granite_orm/transactions/create_spec.cr
@@ -11,7 +11,7 @@ module {{adapter.capitalize.id}}
 
     it "does not create an invalid object" do
       parent = Parent.create(name: "")
-      parent.id?.should be_nil
+      parent.id.should be_nil
     end
 
     describe "with a custom primary key" do

--- a/spec/granite_orm/transactions/destroy_spec.cr
+++ b/spec/granite_orm/transactions/destroy_spec.cr
@@ -10,7 +10,7 @@ module {{adapter.capitalize.id}}
 
       id = parent.id
       parent.destroy
-      found = Parent.find? id
+      found = Parent.find id
       found.should be_nil
     end
 
@@ -37,7 +37,7 @@ module {{adapter.capitalize.id}}
         primary_key = school.custom_id
         school.destroy
 
-        found_school = School.find? primary_key
+        found_school = School.find primary_key
         found_school.should be_nil
       end
     end
@@ -50,7 +50,7 @@ module {{adapter.capitalize.id}}
         primary_key = county.id
         county.destroy
 
-        found_county = Nation::County.find? primary_key
+        found_county = Nation::County.find primary_key
         found_county.should be_nil
       end
     end

--- a/spec/granite_orm/transactions/save_natural_key_spec.cr
+++ b/spec/granite_orm/transactions/save_natural_key_spec.cr
@@ -14,7 +14,7 @@ module {{adapter.capitalize.id}}
       kv.k = "foo"
       kv.save.should be_true
 
-      kv = Kvs.find("foo").not_nil!
+      kv = Kvs.find!("foo")
       kv.k.should eq("foo")
     end
 
@@ -43,7 +43,7 @@ module {{adapter.capitalize.id}}
       Kvs.count.should eq(1)
 
       ## Read
-      port = Kvs.find("mysql_port")
+      port = Kvs.find!("mysql_port")
       port.v.should eq("3306")
       port.new_record?.should be_false
 

--- a/spec/granite_orm/transactions/save_spec.cr
+++ b/spec/granite_orm/transactions/save_spec.cr
@@ -14,7 +14,7 @@ module {{adapter.capitalize.id}}
       parent = Parent.new
       parent.name = ""
       parent.save
-      parent.id?.should be_nil
+      parent.id.should be_nil
     end
 
     it "updates an existing object" do
@@ -28,7 +28,7 @@ module {{adapter.capitalize.id}}
       parents = Parent.all
       parents.size.should eq 1
 
-      found = Parent.first
+      found = Parent.first!
       found.name.should eq parent.name
     end
 
@@ -38,7 +38,7 @@ module {{adapter.capitalize.id}}
       parent.save
       parent.name = ""
       parent.save
-      parent = Parent.find parent.id
+      parent = Parent.find! parent.id
       parent.name.should eq "Test Parent"
     end
 
@@ -74,7 +74,7 @@ module {{adapter.capitalize.id}}
         school.name = new_name
         school.save
 
-        found_school = School.find primary_key
+        found_school = School.find! primary_key
         found_school.custom_id.should eq primary_key
         found_school.name.should eq new_name
       end
@@ -112,7 +112,7 @@ module {{adapter.capitalize.id}}
         county.name = new_name
         county.save
 
-        found_county = Nation::County.find primary_key
+        found_county = Nation::County.find! primary_key
         found_county.name.should eq new_name
       end
     end

--- a/src/granite_orm/associations.cr
+++ b/src/granite_orm/associations.cr
@@ -9,7 +9,7 @@ module Granite::ORM::Associations
 
     # retrieve the parent relationship
     def {{model_name.id}}
-      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id?
+      if parent = {{model_name.id.camelcase}}.find {{model_name.id}}_id
         parent
       else
         {{model_name.id.camelcase}}.new
@@ -27,20 +27,20 @@ module Granite::ORM::Associations
       {% children_class = children_table.id[0...-1].camelcase %}
       {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
       {% table_name = SETTINGS[:table_name] || name_space + "s" %}
-      return [] of {{children_class}} unless id?
+      return [] of {{children_class}} unless id
       foreign_key = "{{children_table.id}}.{{table_name[0...-1]}}_id"
       query = "WHERE #{foreign_key} = ?"
       {{children_class}}.all(query, id)
     end
   end
-  
+
   # define getter for related children
   macro has_many(children_table, through)
     def {{children_table.id}}
       {% children_class = children_table.id[0...-1].camelcase %}
       {% name_space = @type.name.gsub(/::/, "_").downcase.id %}
       {% table_name = SETTINGS[:table_name] || name_space + "s" %}
-      return [] of {{children_class}} unless id?
+      return [] of {{children_class}} unless id
       query = "JOIN {{through.id}} ON {{through.id}}.{{children_table.id[0...-1]}}_id = {{children_table.id}}.id "
       query = query + "WHERE {{through.id}}.{{table_name[0...-1]}}_id = ?"
       {{children_class}}.all(query, id)

--- a/src/granite_orm/fields.cr
+++ b/src/granite_orm/fields.cr
@@ -31,8 +31,8 @@ module Granite::ORM::Fields
 
     # Create the properties
     {% for name, type in FIELDS %}
-      property? {{name.id}} : Union({{type.id}} | Nil)
-      def {{name.id}}
+      property {{name.id}} : Union({{type.id}} | Nil)
+      def {{name.id}}!
         raise {{@type.name.stringify}} + "#" + {{name.stringify}} + " cannot be nil" if @{{name.id}}.nil?
         @{{name.id}}.not_nil!
       end
@@ -52,9 +52,9 @@ module Granite::ORM::Fields
       parsed_params = [] of DB::Any
       {% for name, type in CONTENT_FIELDS %}
         {% if type.id == Time.id %}
-          parsed_params << {{name.id}}?.try(&.to_s("%F %X"))
+          parsed_params << {{name.id}}.try(&.to_s("%F %X"))
         {% else %}
-          parsed_params << {{name.id}}?
+          parsed_params << {{name.id}}
         {% end %}
       {% end %}
       return parsed_params
@@ -65,11 +65,11 @@ module Granite::ORM::Fields
 
       {% for name, type in FIELDS %}
         {% if type.id == Time.id %}
-          fields["{{name}}"] = {{name.id}}?.try(&.to_s("%F %X"))
+          fields["{{name}}"] = {{name.id}}.try(&.to_s("%F %X"))
         {% elsif type.id == Slice.id %}
-          fields["{{name}}"] = {{name.id}}?.try(&.to_s(""))
+          fields["{{name}}"] = {{name.id}}.try(&.to_s(""))
         {% else %}
-          fields["{{name}}"] = {{name.id}}?
+          fields["{{name}}"] = {{name.id}}
         {% end %}
       {% end %}
 
@@ -79,7 +79,7 @@ module Granite::ORM::Fields
     def to_json(json : JSON::Builder)
       json.object do
         {% for name, type in FIELDS %}
-          %field, %value = "{{name.id}}", {{name.id}}?
+          %field, %value = "{{name.id}}", {{name.id}}
           {% if type.id == Time.id %}
             json.field %field, %value.try(&.to_s("%F %X"))
           {% elsif type.id == Slice.id %}

--- a/src/granite_orm/querying.cr
+++ b/src/granite_orm/querying.cr
@@ -1,6 +1,6 @@
 module Granite::ORM::Querying
   class NotFound < Exception
-  end  
+  end
 
   macro extended
     macro __process_querying
@@ -58,27 +58,27 @@ module Granite::ORM::Querying
   end
 
   # First adds a `LIMIT 1` clause to the query and returns the first result
-  def first?(clause = "", params = [] of DB::Any)
+  def first(clause = "", params = [] of DB::Any)
     all([clause.strip, "LIMIT 1"].join(" "), params).first?
   end
 
-  def first(clause = "", params = [] of DB::Any)
-    first?(clause, params) || raise NotFound.new("Couldn't find " + {{@type.name.stringify}} + " with first(#{clause})")
+  def first!(clause = "", params = [] of DB::Any)
+    first(clause, params) || raise NotFound.new("Couldn't find " + {{@type.name.stringify}} + " with first(#{clause})")
   end
 
   # find returns the row with the primary key specified.
   # it checks by primary by default, but one can pass
   # another field for comparison
-  def find?(value)
-    return find_by?(@@primary_name, value)
-  end
-
   def find(value)
     return find_by(@@primary_name, value)
   end
 
+  def find!(value)
+    return find_by!(@@primary_name, value)
+  end
+
   # find_by returns the first row found where the field maches the value
-  def find_by?(field : String | Symbol, value)
+  def find_by(field : String | Symbol, value)
     row = nil
     @@adapter.select_one(@@table_name, fields, field.to_s, value) do |result|
       row = from_sql(result) if result
@@ -86,8 +86,8 @@ module Granite::ORM::Querying
     return row
   end
 
-  def find_by(field : String | Symbol, value)
-    find_by?(field, value) || raise NotFound.new("Couldn't find " + {{@type.name.stringify}} + " with #{field}=#{value}")
+  def find_by!(field : String | Symbol, value)
+    find_by(field, value) || raise NotFound.new("Couldn't find " + {{@type.name.stringify}} + " with #{field}=#{value}")
   end
 
   def find_each(clause = "", params = [] of DB::Any, batch_size limit = 100, offset = 0)

--- a/src/granite_orm/table.cr
+++ b/src/granite_orm/table.cr
@@ -45,9 +45,9 @@ module Granite::ORM::Table
     @@primary_name = "{{primary_name}}"
     @@primary_auto = "{{primary_auto}}"
 
-    property? {{primary_name}} : Union({{primary_type.id}} | Nil)
+    property {{primary_name}} : Union({{primary_type.id}} | Nil)
 
-    def {{primary_name}}
+    def {{primary_name}}!
       raise {{@type.name.stringify}} + "#" + {{primary_name.stringify}} + " cannot be nil" if @{{primary_name}}.nil?
       @{{primary_name}}.not_nil!
     end


### PR DESCRIPTION
I made this change because the previous syntax was a major breaking change that
is not compatible with the Amber templates.  This accomplishes the same thing
but changes the default to be nilable and adds a bang version for `.not_nil!` equivalent.

This will allow us to avoid changing the Amber templates and is backward compatible so we don't break a bunch of peoples existing websites.

Its always recommended to check and see if a `first`, `find`, or `find_by` returns results but if you are absolutely sure you know the results will return, you can use the simpler `first!`, `find!`, or `find_by!` which will throw a runtime exception.

Same with fields, its best to check for `nil` values but if you are absolutely sure the value is not nil, then you can use the simpler `!` version of the field.  This also will throw a runtime exception if it is nil.

I recommend using these sparingly and only in quick prototypes, specs or throw away code.
